### PR TITLE
Tweak Windows 2016

### DIFF
--- a/answer_files/2016/Autounattend.xml
+++ b/answer_files/2016/Autounattend.xml
@@ -5,11 +5,11 @@
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
-            <InputLocale>en-US</InputLocale>
-            <SystemLocale>en-US</SystemLocale>
+            <InputLocale>de-DE</InputLocale>
+            <SystemLocale>de-DE</SystemLocale>
             <UILanguage>en-US</UILanguage>
             <UILanguageFallback>en-US</UILanguageFallback>
-            <UserLocale>en-US</UserLocale>
+            <UserLocale>de-DE</UserLocale>
         </component>
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DiskConfiguration>
@@ -80,7 +80,7 @@
                 <HelpCustomized>false</HelpCustomized>
             </OEMInformation>
             <ComputerName>vagrant-2016</ComputerName>
-            <TimeZone>Pacific Standard Time</TimeZone>
+            <TimeZone>W. Europe Standard Time</TimeZone>
             <RegisteredOwner/>
         </component>
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">

--- a/scripts/uac-enable.bat
+++ b/scripts/uac-enable.bat
@@ -1,0 +1,1 @@
+reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /f /v EnableLUA /t REG_DWORD /d 1

--- a/windows_2016.json
+++ b/windows_2016.json
@@ -77,7 +77,7 @@
         "./scripts/enable-rdp.bat",
         "./scripts/install-containers.bat",
         "./scripts/install-docker.bat",
-        "./scripts/disable-auto-logon.bat"
+        "./scripts/uac-enable.bat"
       ]
     },
     {


### PR DESCRIPTION
- Enable UAC
- Set keyboard layout to de-DE
- Re-enable auto-login.
- Set time zone to Berlin