### PR TITLE
WIP: Add Hyper-V support

### DIFF
--- a/answer_files/2016/Autounattend.xml
+++ b/answer_files/2016/Autounattend.xml
@@ -182,15 +182,14 @@
                     <Description>Disable password expiration for vagrant user</Description>
                 </SynchronousCommand>
                 <!-- WITHOUT WINDOWS UPDATES -->
-                <!--
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\enable-winrm.ps1</CommandLine>
                     <Description>Enable WinRM</Description>
                     <Order>99</Order>
                 </SynchronousCommand>
-                -->
                 <!-- END WITHOUT WINDOWS UPDATES -->
                 <!-- WITH WINDOWS UPDATES -->
+            <!--
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>
                     <Order>98</Order>
@@ -202,6 +201,7 @@
                     <Order>100</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
+              -->
                 <!-- END WITH WINDOWS UPDATES -->
             </FirstLogonCommands>
             <OOBE>

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+packer build --only=hyperv-iso --var iso_url=./iso/win2016tp5.iso --var hyperv_switchname=packer windows_2016_docker.json

--- a/scripts/docker/add-docker-group.ps1
+++ b/scripts/docker/add-docker-group.ps1
@@ -1,5 +1,6 @@
 net localgroup docker /add
-net localgroup docker vagrant /add
+$username = "vagrant"
+net localgroup docker $username /add
 
 (Get-Content C:\ProgramData\docker\runDockerDaemon.cmd).replace('-H npipe://', '-G docker -H npipe://') | Set-Content C:\ProgramData\docker\runDockerDaemon.cmd
 

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -1,6 +1,36 @@
 {
   "builders": [
     {
+      "vm_name":"windows2016",
+      "type": "hyperv-iso",
+      "disk_size": 61440,
+      "floppy_files":  [
+        "./answer_files/2016/Autounattend.xml",
+        "./floppy/WindowsPowershell.lnk",
+        "./floppy/PinTo10.exe",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/docker/enable-winrm.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "boot_wait": "2m",
+      "headless": false,
+      "guest_additions_mode":"disable",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "communicator":"winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout" : "4h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "ram_size_mb": 2048,
+      "cpu": 2,
+      "generation": 1,
+      "switch_name":"{{user `hyperv_switchname`}}",
+      "enable_secure_boot": true
+    },
+    {
       "type": "vmware-iso",
       "communicator": "winrm",
       "iso_url": "{{user `iso_url`}}",

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -43,7 +43,7 @@
       "winrm_timeout": "6h",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows8srv-64",
-      "disk_size": 61440,
+      "disk_size": 31440,
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "version": 11,
@@ -128,9 +128,9 @@
     },
     {
       "type": "powershell",
+      "execute_command": "powershell \"& { {{.Vars}}{{.Path}}; exit $LastExitCode}\"",
       "scripts": [
         "./scripts/docker/install-docker.ps1",
-        "./scripts/docker/patch-boot-time-for-containers.ps1",
         "./scripts/docker/enable-docker-insecure.ps1",
         "./scripts/docker/add-docker-group.ps1",
         "./scripts/docker/remove-docker-key-json.ps1"
@@ -140,9 +140,7 @@
       "type": "windows-shell",
       "scripts": [
         "./scripts/set-winrm-automatic.bat",
-        "./scripts/uac-enable.bat",
-        "./scripts/compile-dotnet-assemblies.bat",
-        "./scripts/compact.bat"
+        "./scripts/uac-enable.bat"
       ]
     }
   ],


### PR DESCRIPTION
This is a work in progress to build a Hyper-V VM for Windows Server 2016 TP5 + Docker.
I open a PR so others can review and comment on this work.

My setup:

* Windows 10 Pro + Hyper-V enabled, 5 GByte RAM, 2 CPU's, running in a VMware Fusion VM on my Mac with nested virtualization.
* Use prebuilt packer.exe from https://dl.bintray.com/taliesins/Packer/Packer.1.0.0.104-HyperV.nupkg
* Packer template switched back to VM generation 1 as this supports floppy files.

Current issues:

* The Hyper-V doesn't seem to have internet connection, so win-updates.bat does not work ...
  * **Solution**: Change the packer-hyperv-iso virtual switch from internal network to external network, in my case vmxnet3 Ethernet Adapter

