### PR TITLE
Always install nanoserver image, works without hyperv

### DIFF
--- a/scripts/docker/install-docker.ps1
+++ b/scripts/docker/install-docker.ps1
@@ -14,10 +14,6 @@ Write-Host "Installing WindowsServerCore container image..."
 & "C:\Program Files\docker\docker.exe" pull microsoft/windowsservercore:10.0.14393.321
 & "C:\Program Files\docker\docker.exe" tag microsoft/windowsservercore:10.0.14393.321 microsoft/windowsservercore:latest
 
-if ((get-windowsfeature Hyper-V | where installed).count) {
-  Write-Host "Installing NanoServer container image..."
-  & "C:\Program Files\docker\docker.exe" pull microsoft/nanoserver:10.0.14393.321
-  & "C:\Program Files\docker\docker.exe" tag microsoft/nanoserver:10.0.14393.321 microsoft/nanoserver:latest
-} else {
-  Write-Host "Skipping NanoServer container image"
-}
+Write-Host "Installing NanoServer container image..."
+& "C:\Program Files\docker\docker.exe" pull microsoft/nanoserver:10.0.14393.321
+& "C:\Program Files\docker\docker.exe" tag microsoft/nanoserver:10.0.14393.321 microsoft/nanoserver:latest


### PR DESCRIPTION
With the latest docker engine and 321 base images both windowsservercore and nanoserver containers can be started without Hyper-V. So always install nanoserver.