### PR TITLE
WIP: Use OneGet package to install Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following Windows versions are known to work (built with VMware Fusion Pro 8
 
  * Windows 10
  * Windows Server 2016
- * Windows Server 2016 with Hyper-V and Docker -> see [docker-windows-box](https://github.com/StefanScherer/docker-windows-box) for an use case
+ * Windows Server 2016 and Docker -> see [docker-windows-box](https://github.com/StefanScherer/docker-windows-box) for an use case
 
 You may find other packer template files, but older versions of Windows doesn't work so nice with a Retina display.
 

--- a/scripts/docker/add-docker-group.ps1
+++ b/scripts/docker/add-docker-group.ps1
@@ -3,3 +3,7 @@ net localgroup docker /add
 $username = $env:USERNAME
 Write-Host Adding user $username to group docker
 net localgroup docker $username /add
+
+$env:Path = $env:Path + ";$($env:ProgramFiles)\docker"
+. dockerd --unregister-service
+. dockerd --register-service -H npipe:// -H 0.0.0.0:2375 -G docker

--- a/scripts/docker/docker-pull-baseimages.ps1
+++ b/scripts/docker/docker-pull-baseimages.ps1
@@ -1,0 +1,7 @@
+Write-Host "Installing WindowsServerCore container image..."
+& docker pull microsoft/windowsservercore:10.0.14393.321
+& docker tag microsoft/windowsservercore:10.0.14393.321 microsoft/windowsservercore:latest
+
+Write-Host "Installing NanoServer container image..."
+& docker pull microsoft/nanoserver:10.0.14393.321
+& docker tag microsoft/nanoserver:10.0.14393.321 microsoft/nanoserver:latest

--- a/scripts/docker/install-docker.ps1
+++ b/scripts/docker/install-docker.ps1
@@ -1,5 +1,16 @@
+Get-PackageSource
+Write-Host "Install-PackageProvider ..."
 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+Get-PackageSource
+Write-Host "Install-Module ..."
 Install-Module -Name DockerMsftProvider -Force
+Get-PackageSource
+Write-Host "Set-PSRepository trusted ..."
 Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
+Write-Host "Install-Package ..."
 Install-Package -Name docker -ProviderName DockerMsftProvider -Force
+Write-Host "Set-PSRepository untrusted ..."
 Set-PSRepository -InstallationPolicy Untrusted -Name PSGallery
+Write-Host "Fix --restart=always for reboot ..."
+# see https://github.com/docker/docker/issues/27544
+& sc config Docker depend=LanmanWorkstation

--- a/scripts/docker/install-docker.ps1
+++ b/scripts/docker/install-docker.ps1
@@ -1,0 +1,5 @@
+Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+Install-Module -Name DockerMsftProvider -Force
+Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
+Install-Package -Name docker -ProviderName DockerMsftProvider -Force
+Set-PSRepository -InstallationPolicy Untrusted -Name PSGallery

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -15,8 +15,12 @@
         "./floppy/PinTo10.exe",
         "./scripts/disable-screensaver.ps1",
         "./scripts/disable-winrm.ps1",
+<<<<<<< HEAD
         "./scripts/docker/enable-winrm.ps1",
         "./scripts/docker/2016/install-containers-feature.ps1",
+=======
+        "./scripts/enable-winrm.ps1",
+>>>>>>> Use OneGet package to install Docker
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
@@ -55,8 +59,12 @@
         "./floppy/PinTo10.exe",
         "./scripts/disable-screensaver.ps1",
         "./scripts/disable-winrm.ps1",
+<<<<<<< HEAD
         "./scripts/docker/enable-winrm.ps1",
         "./scripts/docker/2016/install-containers-feature.ps1",
+=======
+        "./scripts/enable-winrm.ps1",
+>>>>>>> Use OneGet package to install Docker
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
@@ -65,8 +73,12 @@
         "RemoteDisplay.vnc.port": "5900",
         "memsize": "2048",
         "numvcpus": "2",
+<<<<<<< HEAD
         "scsi0.virtualDev": "lsisas1068",
         "vhv.enable": "FALSE"
+=======
+        "scsi0.virtualDev": "lsisas1068"
+>>>>>>> Use OneGet package to install Docker
       }
     },
     {
@@ -92,8 +104,12 @@
         "./floppy/PinTo10.exe",
         "./scripts/disable-screensaver.ps1",
         "./scripts/disable-winrm.ps1",
+<<<<<<< HEAD
         "./scripts/docker/enable-winrm.ps1",
         "./scripts/docker/2016/install-containers-feature.ps1",
+=======
+        "./scripts/enable-winrm.ps1",
+>>>>>>> Use OneGet package to install Docker
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1",
         "./scripts/oracle-cert.cer"
@@ -126,7 +142,12 @@
     {
       "type": "powershell",
       "scripts": [
+<<<<<<< HEAD
         "./scripts/debloat-windows.ps1"
+=======
+        "./scripts/docker/install-docker.ps1",
+        "./scripts/docker/add-docker-group.ps1"
+>>>>>>> Use OneGet package to install Docker
       ]
     },
     {
@@ -143,9 +164,13 @@
     {
       "type": "powershell",
       "scripts": [
+<<<<<<< HEAD
         "./scripts/docker/add-docker-group.ps1",
         "./scripts/docker/2016/install-docker.ps1",
         "./scripts/docker/docker-pull-async.ps1",
+=======
+        "./scripts/docker/docker-pull-baseimages.ps1",
+>>>>>>> Use OneGet package to install Docker
         "./scripts/docker/open-docker-insecure-port.ps1",
         "./scripts/docker/remove-docker-key-json.ps1",
         "./scripts/docker/disable-windows-defender.ps1"


### PR DESCRIPTION
Install Docker with the OneGet package. Get rid of a duplicate enable-winrm.ps1 script for docker.

Current problem 

```
==> vmware-iso: Provisioning with shell script: ./scripts/docker/install-docker.ps1
    vmware-iso:
    vmware-iso: Name                           Version          Source           Summary
    vmware-iso: ----                           -------          ------           -------
    vmware-iso: nuget                          2.8.5.207        https://onege... NuGet provider for the OneGet meta-package manager
    vmware-iso: WARNING: Cannot find path 'C:\Users\vagrant\AppData\Local\Temp\DockerMsftProvider\DockerDefault_DockerSearchIndex.json'
    vmware-iso: Install-Package : No match was found for the specified search criteria and package name 'docker'. Try
    vmware-iso: Get-PackageSource to see all available registered package sources.
    vmware-iso: At C:\Windows\Temp\script.ps1:4 char:1
    vmware-iso: because it does not exist.
    vmware-iso: WARNING: Save-HTTPItem: Bits Transfer failed. Job State:  ExitCode = -2147023651
    vmware-iso: + Install-Package -Name docker -ProviderName DockerMsftProvider -Force
    vmware-iso: + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    vmware-iso: + CategoryInfo          : ObjectNotFound: (Microsoft.Power....InstallPackage:InstallPackage) [Install-Package], Ex
    vmware-iso: ception
    vmware-iso: + FullyQualifiedErrorId : NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackage
    vmware-iso:
```
