### PR TITLE
Install Docker 1.13.0-rc3

### DIFF
--- a/scripts/docker/install-docker.ps1
+++ b/scripts/docker/install-docker.ps1
@@ -1,10 +1,10 @@
 Set-ExecutionPolicy Bypass -scope Process
 New-Item -Type Directory -Path "$($env:ProgramFiles)\docker"
 # wget -outfile $env:TEMP\docker-cs-1.12.zip "https://download.docker.com/components/engine/windows-server/cs-1.12/docker-1.12.2.zip"
-wget -outfile $env:TEMP\docker-1.13.0-rc2.zip "https://test.docker.com/builds/Windows/x86_64/docker-1.13.0-rc2.zip"
-Expand-Archive -Path $env:TEMP\docker-1.13.0-rc2.zip -DestinationPath $env:TEMP -Force
+wget -outfile $env:TEMP\docker-1.13.0-rc3.zip "https://test.docker.com/builds/Windows/x86_64/docker-1.13.0-rc3.zip"
+Expand-Archive -Path $env:TEMP\docker-1.13.0-rc3.zip -DestinationPath $env:TEMP -Force
 copy $env:TEMP\docker\*.exe $env:ProgramFiles\docker
-Remove-Item $env:TEMP\docker-1.13.0-rc2.zip
+Remove-Item $env:TEMP\docker-1.13.0-rc3.zip
 [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$($env:ProgramFiles)\docker", [EnvironmentVariableTarget]::Machine)
 $env:Path = $env:Path + ";$($env:ProgramFiles)\docker"
 . dockerd --register-service -H npipe:// -H 0.0.0.0:2375 -G docker


### PR DESCRIPTION
Currently it's better to use the release candidates on Windows, so update to latest 1.13.0-rc3 until the next CS version is available for Win2016.