### PR TITLE
windows_2016_docker: small changes I needed to make to get it to build

### DIFF
--- a/scripts/docker/docker-pull-async.ps1
+++ b/scripts/docker/docker-pull-async.ps1
@@ -12,5 +12,3 @@ function DockerPull {
   $results
 }
 
-DockerPull microsoft/windowsservercore
-DockerPull microsoft/nanoserver

--- a/scripts/docker/enable-winrm.ps1
+++ b/scripts/docker/enable-winrm.ps1
@@ -15,7 +15,11 @@ if (Test-Path A:\install-containers-feature.ps1) {
 Stop-Service winrm
 . sc.exe config winrm start= delayed-auto
 
+Set-Service winrm -startuptype "auto"
+
 netsh advfirewall firewall set rule group="Windows Remote Administration" new enable=yes
 netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=allow
 
-Restart-Computer
+Restart-Service winrm
+
+# Restart-Computer

--- a/scripts/vm-guest-tools.bat
+++ b/scripts/vm-guest-tools.bat
@@ -22,7 +22,7 @@ if not exist "C:\Windows\Temp\windows.iso" (
 )
 
 cmd /c ""C:\Program Files\7-Zip\7z.exe" x "C:\Windows\Temp\windows.iso" -oC:\Windows\Temp\VMWare"
-cmd /c C:\Windows\Temp\VMWare\setup.exe /S /v"/qn REBOOT=R\"
+cmd /c C:\Windows\Temp\VMWare\setup64.exe /S /v"/qn REBOOT=R\"
 
 rd /Q "C:\Windows\Temp\vmware-tools.tar"
 rd /Q "C:\Windows\Temp\windows.iso"


### PR DESCRIPTION
It appears that the small changes I made here allowed the windows_2016_docker to build to completion.

0. Make sure you're using a recent version of packer. I tried initially to use packer 0.8.6, and that wasn't getting anywhere. Using packer 0.12.2 appears to have let it start trying to use winrm instead of ssh.

1. Enabling winrm throughout seemed to be the key piece that fixed this. Before this fix, the system rebooted right after enabling winrm and the service wasn't set to auto, effectively halting the build. Re-running the script after reboot let it run long enough to reboot, which resulted in a partial build from half-installed bits.

2. There was a problem trying to install the vmware tools using setup.exe (not found), but that may have been an interim build problem.

3. Removing the DockerPull for microsoft/windowsservercore and microsoft/nanoserver core results in a 500M .box file which is manageable. 