### PR TITLE
Switch to DockerMsftProviderInsider 

### DIFF
--- a/scripts/docker/2016/install-docker.ps1
+++ b/scripts/docker/2016/install-docker.ps1
@@ -1,14 +1,9 @@
-Get-PackageSource
 Write-Host "Install-PackageProvider ..."
 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-Get-PackageSource
 Write-Host "Install-Module ..."
 Install-Module -Name DockerMsftProviderInsider -Force
-Get-PackageSource
-Write-Host "Set-PSRepository trusted ..."
-Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
 Write-Host "Install-Package ..."
+Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
 Install-Package -Name docker -ProviderName DockerMsftProviderInsider -Force
-Write-Host "Set-PSRepository untrusted ..."
 Set-PSRepository -InstallationPolicy Untrusted -Name PSGallery
 Start-Service docker

--- a/scripts/docker/2016/install-docker.ps1
+++ b/scripts/docker/2016/install-docker.ps1
@@ -1,12 +1,14 @@
-$ProgressPreference = 'SilentlyContinue'
-
-Set-ExecutionPolicy Bypass -scope Process
-New-Item -Type Directory -Path "$($env:ProgramFiles)\docker"
-wget -outfile $env:TEMP\docker-17-03-1-ee.zip "https://dockermsft.blob.core.windows.net/dockercontainer/docker-17-03-1-ee.zip"
-Expand-Archive -Path $env:TEMP\docker-17-03-1-ee.zip -DestinationPath $env:TEMP -Force
-copy $env:TEMP\docker\*.exe $env:ProgramFiles\docker
-Remove-Item $env:TEMP\docker-17-03-1-ee.zip
-[Environment]::SetEnvironmentVariable("Path", $env:Path + ";$($env:ProgramFiles)\docker", [EnvironmentVariableTarget]::Machine)
-$env:Path = $env:Path + ";$($env:ProgramFiles)\docker"
-. dockerd --register-service -H npipe:// -H 0.0.0.0:2375 -G docker
+Get-PackageSource
+Write-Host "Install-PackageProvider ..."
+Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+Get-PackageSource
+Write-Host "Install-Module ..."
+Install-Module -Name DockerMsftProviderInsider -Force
+Get-PackageSource
+Write-Host "Set-PSRepository trusted ..."
+Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
+Write-Host "Install-Package ..."
+Install-Package -Name docker -ProviderName DockerMsftProviderInsider -Force
+Write-Host "Set-PSRepository untrusted ..."
+Set-PSRepository -InstallationPolicy Untrusted -Name PSGallery
 Start-Service docker


### PR DESCRIPTION
Use the Insider build of https://github.com/OneGet/MicrosoftDockerProvider to use the official steps how to install Docker EE in Windows Server 2016.

This Insider build has a fix for https://github.com/OneGet/MicrosoftDockerProvider/issues/18 to use `Invoke-WebRequest` instead of the BITS transfer which hangs while provisioning through the packer WinRM connection.

Replaces #17
