### PR TITLE
use the correct windows insider image name

### DIFF
--- a/answer_files/2016_insider/Autounattend.xml
+++ b/answer_files/2016_insider/Autounattend.xml
@@ -50,8 +50,8 @@
                 <OSImage>
                     <InstallFrom>
                         <MetaData wcm:action="add">
-                            <Key>/IMAGE/NAME </Key>
-                            <Value>Windows Server 2016 Datacenter</Value>
+                            <Key>/IMAGE/NAME</Key>
+                            <Value>Windows Server 2016 SERVERDATACENTERACORE</Value>
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>

--- a/answer_files/2016_insider/Autounattend.xml
+++ b/answer_files/2016_insider/Autounattend.xml
@@ -62,7 +62,10 @@
             </ImageInstall>
             <UserData>
                 <ProductKey>
-                    <!-- Windows Server Insider product key -->
+                    <!--
+                        Windows Server Insider product key
+                        See https://blogs.windows.com/windowsexperience/2017/07/13/announcing-windows-server-insider-preview-build-16237/
+                    -->
                     <Key>B69WH-PRNHK-BXVK3-P9XF7-XD84W</Key>
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>


### PR DESCRIPTION
I found the correct name by using the Windows System Image Manager (WSIM) application that is included in the Windows Assessment and Deployment Kit (ADK).

BTW, I also have a version of a windows base box at https://github.com/rgl/windows-2016-vagrant.

BTW is there a reason for not using scripts/docker/2016/install-docker.ps1 to install docker in the insider version? its currently using the scripts/docker/10/install-docker.ps1 version.