### PR TITLE
Updating hyperv-iso on windows_2016_docker_core.json and windows_2016_insider.json

### DIFF
--- a/windows_2016_docker_core.json
+++ b/windows_2016_docker_core.json
@@ -1,6 +1,33 @@
 {
   "builders": [
     {
+      "vm_name":"WindowsServer2016CoreDocker",
+      "type": "hyperv-iso",
+      "disk_size": 41440,
+      "boot_wait": "0s",
+      "guest_additions_mode":"disable",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/docker/enable-winrm.ps1",
+        "./scripts/docker/2016/install-containers-feature.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "communicator":"winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout" : "4h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "ram_size": 2048,
+      "cpu": 2,
+      "switch_name":"{{user `hyperv_switchname`}}",
+      "enable_secure_boot":true,
+      "enable_virtualization_extensions":true
+    },
+    {
       "type": "virtualbox-iso",
       "communicator": "winrm",
       "iso_url": "{{user `iso_url`}}",
@@ -60,7 +87,7 @@
       "type": "powershell",
       "scripts": [
         "./scripts/docker/add-docker-group.ps1",
-        "./scripts/docker/install-docker.ps1",
+        "./scripts/docker/2016/install-docker.ps1",
         "./scripts/docker/docker-pull-async.ps1",
         "./scripts/docker/open-docker-insecure-port.ps1",
         "./scripts/docker/remove-docker-key-json.ps1",

--- a/windows_2016_insider.json
+++ b/windows_2016_insider.json
@@ -23,7 +23,8 @@
       "ram_size": 2048,
       "cpu": 2,
       "switch_name":"{{user `hyperv_switchname`}}",
-      "enable_secure_boot":true
+      "enable_secure_boot":true,
+      "enable_virtualization_extensions":true
     },
     {
       "type": "vmware-iso",


### PR DESCRIPTION
Just a few quick updates:

- `windows_2016_docker_core.json` was missing the `hyperv-iso` builder
- `windows_2016_insider.json` `hyperv-iso` builder needs `"enable_virtualization_extensions":true` to run Linux containers soon