### PR TITLE
updating to latest isos

### DIFF
--- a/windows_10_insider.json
+++ b/windows_10_insider.json
@@ -130,9 +130,9 @@
   ],
   "variables": {
     "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewadvanced",
-    "iso_url": "https://software-download.microsoft.com/pr/Windows10_InsiderPreview_EnterpriseVL_x64_en-us_16232.iso",
-    "iso_checksum_type": "sha1",
-    "iso_checksum": "8e84a14b972a2d7643d347c57068b51e88e86ae5",
+    "iso_url": "https://software-download.microsoft.com/pr/Windows10_InsiderPreview_EnterpriseVL_x64_en-us_16251.iso",
+    "iso_checksum_type": "sha256",
+    "iso_checksum": "CA0715B5646FBD18376F9A370BB1A2DF8A94DDB3F1BF107843C357E7DAD417FF",
     "autounattend": "./answer_files/10_insider/Autounattend.xml",
     "disk_size": "61440"
   }

--- a/windows_2016_insider.json
+++ b/windows_2016_insider.json
@@ -142,9 +142,10 @@
     }
   ],
   "variables": {
-    "iso_url": "https://software-download.microsoft.com/pr/Windows_InsiderPreview_Server_16257.iso",
+    "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
+    "iso_url": "https://software-download.microsoft.com/pr/Windows_InsiderPreview_Server_16267.iso",
     "iso_checksum_type": "sha256",
-    "iso_checksum": "B988201B8019A272D67F5F6737F2180BFEDCC2CF5B065AAB7FBCEB43EAA7D995",
+    "iso_checksum": "1FA3EEED8555DD6E120727A7DB6B47B2987357B7001F6B5AF2A732A12CB61EC3",
     "autounattend": "./answer_files/2016_insider/Autounattend.xml"
   }
 }


### PR DESCRIPTION
The Windows 10 Insider ISO links are still lagging behind what's available in the flights. I don't know why. Regardless, these are the latest links & hashes as of 27 August.