### PR TITLE
Updating Windows 10 insider scripts for Hyper-V

### DIFF
--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -55,4 +55,10 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.enable_vmrun_ip_lookup = false
     end
+
+    config.vm.provider "hyperv" do |v|
+        v.cpus = 2
+        v.maxmemory = 2048
+        v.differencing_disk = true
+    end
 end

--- a/windows_10_insider.json
+++ b/windows_10_insider.json
@@ -79,7 +79,38 @@
           "2"
         ]
       ]
-    }
+    },
+    {
+      "type": "hyperv-iso",
+      "communicator": "winrm",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": false,
+      "boot_wait": "0s",
+      "guest_additions_mode":"disable",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "2h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./floppy/WindowsPowershell.lnk",
+        "./floppy/PinTo10.exe",
+        "./scripts/fixnetwork.ps1",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/enable-winrm.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "ram_size": 2048,
+      "cpu": 2,
+      "switch_name":"{{user `hyperv_switchname`}}",
+      "enable_secure_boot":true,
+      "enable_virtualization_extensions":true
+    },
   ],
   "provisioners": [
     {

--- a/windows_10_insider.json
+++ b/windows_10_insider.json
@@ -86,7 +86,6 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
       "boot_wait": "0s",
       "guest_additions_mode":"disable",
       "winrm_username": "vagrant",
@@ -110,7 +109,7 @@
       "switch_name":"{{user `hyperv_switchname`}}",
       "enable_secure_boot":true,
       "enable_virtualization_extensions":true
-    },
+    }
   ],
   "provisioners": [
     {


### PR DESCRIPTION
These seem to work with a caveat. They hang during install at the language & keyboard selection page. I think there's an unattend.xml change needed but that's not something that's Hyper-V specific. If I click through those 2 pages during setup the rest completes as expected.