### PR TITLE
Build Windows 2016 headlessly

### DIFF
--- a/windows_2016.json
+++ b/windows_2016.json
@@ -37,7 +37,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -73,7 +73,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -147,6 +147,7 @@
     }
   ],
   "variables": {
+    "headless": "false",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",

--- a/windows_2016_core.json
+++ b/windows_2016_core.json
@@ -33,7 +33,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -65,7 +65,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -131,6 +131,7 @@
     }
   ],
   "variables": {
+    "headless": "false",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",

--- a/windows_2016_dc.json
+++ b/windows_2016_dc.json
@@ -34,7 +34,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -67,7 +67,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -156,6 +156,7 @@
     }
   ],
   "variables": {
+    "headless": "false",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -38,7 +38,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -76,7 +76,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -170,6 +170,7 @@
     }
   ],
   "variables": {
+    "headless": "false",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",

--- a/windows_2016_docker_azure.json
+++ b/windows_2016_docker_azure.json
@@ -1,5 +1,6 @@
 {
  "variables": {
+    "headless": "false",
     "azure_ad_tenant_id": "{{env `PACKER_AZURE_AD_TENANT_ID`}}",
     "azure_subscription_id": "{{env `PACKER_AZURE_SUBSCRIPTION_ID`}}",
     "object_id": "{{env `PACKER_AZURE_OBJECT_ID`}}",

--- a/windows_2016_docker_core.json
+++ b/windows_2016_docker_core.json
@@ -33,7 +33,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": true,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -68,7 +68,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": true,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -150,6 +150,7 @@
     }
   ],
   "variables": {
+    "headless": "false",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",

--- a/windows_2016_hyperv.json
+++ b/windows_2016_hyperv.json
@@ -32,7 +32,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -63,7 +63,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -128,6 +128,7 @@
     }
   ],
   "variables": {
+    "headless": "false",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/8/8/6/886DAAEF-81A7-4418-82D5-07D33B816962/14393.0.161119-1705.RS1_REFRESH_SERVERHYPERCORE_OEM_X64FRE_EN-US.ISO",
     "iso_checksum_type": "sha256",
     "iso_checksum": "53e2f01dc4077192a85f60f8d2ffb02189074e19b25f990cbe9eb767328d3fb6",

--- a/windows_2016_insider.json
+++ b/windows_2016_insider.json
@@ -32,7 +32,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "60s",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -62,7 +62,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "60s",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -142,6 +142,7 @@
     }
   ],
   "variables": {
+    "headless": "false",
     "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
     "iso_url": "https://software-download.microsoft.com/pr/Windows_InsiderPreview_Server_16278.iso",
     "iso_checksum_type": "sha256",


### PR DESCRIPTION
Setting `"headless": false` causes problems for my CI server as it can't run the builds due to lack of gui.

I feel like this should be the default anyway, as you can always connect to the remote console via vnc.