### PR TITLE
Add firewall rules to enable Docker Swarm Mode traffic

### DIFF
--- a/scripts/docker/open-docker-swarm-ports.ps1
+++ b/scripts/docker/open-docker-swarm-ports.ps1
@@ -1,0 +1,14 @@
+Write-Host "Opening Docker swarm mode ports"
+
+if (!(Get-NetFirewallRule | where {$_.Name -eq "Dockerswarm2377"})) {
+    New-NetFirewallRule -Name "Dockerswarm2377" -DisplayName "Docker Swarm Mode Management TCP/2377" -Protocol tcp -LocalPort 2377 -Action Allow -Enabled True
+}
+if (!(Get-NetFirewallRule | where {$_.Name -eq "Dockerswarm7946"})) {
+    New-NetFirewallRule -Name "Dockerswarm7946" -DisplayName "Docker Swarm Mode Node Communication TCP/7946" -Protocol tcp -LocalPort 7946 -Action Allow -Enabled True
+}
+if (!(Get-NetFirewallRule | where {$_.Name -eq "Dockerswarm7946udp"})) {
+    New-NetFirewallRule -Name "Dockerswarm7946udp" -DisplayName "Docker Swarm Mode Node Communication UDP/7946" -Protocol udp -LocalPort 7946 -Action Allow -Enabled True
+}
+if (!(Get-NetFirewallRule | where {$_.Name -eq "Dockerswarm4789"})) {
+    New-NetFirewallRule -Name "Dockerswarm4789" -DisplayName "Docker Swarm Overlay Network Traffic TCP/4789" -Protocol tcp -LocalPort 4789 -Action Allow -Enabled True
+}

--- a/windows_10_docker.json
+++ b/windows_10_docker.json
@@ -40,6 +40,7 @@
         "./scripts/docker/10/install-docker.ps1",
         "./scripts/docker/docker-pull-async.ps1",
         "./scripts/docker/open-docker-insecure-port.ps1",
+        "./scripts/docker/open-docker-swarm-ports.ps1",
         "./scripts/docker/remove-docker-key-json.ps1",
         "./scripts/docker/disable-windows-defender.ps1"
       ]

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -149,6 +149,7 @@
         "./scripts/docker/2016/install-docker.ps1",
         "./scripts/docker/docker-pull-async.ps1",
         "./scripts/docker/open-docker-insecure-port.ps1",
+        "./scripts/docker/open-docker-swarm-ports.ps1",
         "./scripts/docker/remove-docker-key-json.ps1",
         "./scripts/docker/disable-windows-defender.ps1"
       ]

--- a/windows_2016_docker_core.json
+++ b/windows_2016_docker_core.json
@@ -125,6 +125,7 @@
         "./scripts/docker/2016/install-docker.ps1",
         "./scripts/docker/docker-pull-async.ps1",
         "./scripts/docker/open-docker-insecure-port.ps1",
+        "./scripts/docker/open-docker-swarm-ports.ps1",
         "./scripts/docker/remove-docker-key-json.ps1",
         "./scripts/docker/disable-windows-defender.ps1"
       ]

--- a/windows_server_1709.json
+++ b/windows_server_1709.json
@@ -138,6 +138,7 @@
         "./scripts/docker/2016/install-docker-ee-preview.ps1",
         "./scripts/docker/docker-pull-1709-async.ps1",
         "./scripts/docker/open-docker-insecure-port.ps1",
+        "./scripts/docker/open-docker-swarm-ports.ps1",
         "./scripts/docker/remove-docker-key-json.ps1",
         "./scripts/docker/disable-windows-defender.ps1"
       ]


### PR DESCRIPTION
Add script to open firewall ports for Docker Swarm Mode (see: https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/swarm-mode) to Docker-enabled builds.