### PR TITLE
Allow control of restart and winrm timeouts via user variables

### DIFF
--- a/windows_2016.json
+++ b/windows_2016.json
@@ -22,7 +22,7 @@
       "communicator":"winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "a:/sysprep.bat",
       "ram_size": 2048,
       "cpu": 2,
@@ -41,7 +41,7 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "a:/sysprep.bat",
       "guest_os_type": "windows9srv-64",
       "disk_size": 61440,
@@ -77,7 +77,7 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "a:/sysprep.bat",
       "guest_os_type": "Windows2012_64",
       "guest_additions_mode": "disable",
@@ -124,7 +124,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "windows-shell",
@@ -151,6 +152,8 @@
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
     "autounattend": "./answer_files/2016/Autounattend.xml",
-    "hyperv_switchname": "{{env `hyperv_switchname`}}"
+    "hyperv_switchname": "{{env `hyperv_switchname`}}",
+    "restart_timeout": "5m",
+    "winrm_timeout": "2h"
   }
 }

--- a/windows_2016_dc.json
+++ b/windows_2016_dc.json
@@ -20,7 +20,7 @@
       "communicator":"winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "4h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ram_size": 2048,
       "cpu": 2,
@@ -38,7 +38,7 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "6h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows9srv-64",
       "disk_size": 61440,
@@ -71,7 +71,7 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "6h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "Windows2012_64",
       "guest_additions_mode": "disable",
@@ -126,7 +126,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "powershell",
@@ -135,7 +136,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "windows-shell",
@@ -162,6 +164,8 @@
     "autounattend": "./answer_files/2016_core/Autounattend.xml",
     "DomainName": "windomain.local",
     "DomainNetbiosName": "windom",
-    "SafeModeAdministratorPassword": "BadAdminPassword!"
+    "SafeModeAdministratorPassword": "BadAdminPassword!",
+    "restart_timeout": "5m",
+    "winrm_timeout": "6h"
   }
 }

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -23,7 +23,7 @@
       "communicator":"winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "4h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ram_size": 2048,
       "cpu": 2,
@@ -42,7 +42,7 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "6h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows9srv-64",
       "disk_size": "{{user `disk_size`}}",
@@ -81,7 +81,7 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "6h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "post_shutdown_delay": "10s",
       "guest_os_type": "Windows2012_64",
@@ -130,7 +130,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "windows-shell",
@@ -179,6 +180,8 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
-    "autounattend": "./answer_files/2016/Autounattend.xml"
+    "autounattend": "./answer_files/2016/Autounattend.xml",
+    "restart_timeout": "5m",
+    "winrm_timeout": "6h"
   }
 }

--- a/windows_2016_docker_core.json
+++ b/windows_2016_docker_core.json
@@ -19,7 +19,7 @@
       "communicator":"winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "4h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ram_size": 2048,
       "cpu": 2,
@@ -37,7 +37,7 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "6h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows9srv-64",
       "disk_size": 61440,
@@ -72,7 +72,7 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "6h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "Windows2012_64",
       "guest_additions_mode": "disable",
@@ -115,7 +115,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "powershell",
@@ -130,7 +131,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "windows-shell",
@@ -154,6 +156,8 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
-    "autounattend": "./answer_files/2016_core/Autounattend.xml"
+    "autounattend": "./answer_files/2016_core/Autounattend.xml",
+    "restart_timeout": "5m",
+    "winrm_timeout": "6h"
   }
 }

--- a/windows_2016_insider.json
+++ b/windows_2016_insider.json
@@ -18,7 +18,7 @@
       "communicator":"winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ram_size": 2048,
       "cpu": 2,
@@ -36,7 +36,7 @@
       "boot_wait": "60s",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows9srv-64",
       "disk_size": 61440,
@@ -66,7 +66,7 @@
       "boot_wait": "60s",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "Windows2012_64",
       "guest_additions_mode": "disable",
@@ -108,7 +108,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "powershell",
@@ -122,7 +123,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "windows-shell",
@@ -146,6 +148,8 @@
     "iso_url": "https://software-download.microsoft.com/pr/Windows_InsiderPreview_Server_16278.iso",
     "iso_checksum_type": "sha256",
     "iso_checksum": "f87ebde2f4dc7094d2e01819d370cb8d06d2bcde520d3bdf9e8ce7e70a8ea5da",
-    "autounattend": "./answer_files/2016_insider/Autounattend.xml"
+    "autounattend": "./answer_files/2016_insider/Autounattend.xml",
+    "restart_timeout": "5m",
+    "winrm_timeout": "2h"
   }
 }

--- a/windows_server_1709.json
+++ b/windows_server_1709.json
@@ -23,7 +23,7 @@
       "communicator":"winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ram_size": 2048,
       "cpu": 2,
@@ -42,7 +42,7 @@
       "boot_wait": "60s",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "2h",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows9srv-64",
       "disk_size": "{{user `disk_size`}}",
@@ -80,7 +80,7 @@
       "boot_wait": "60s",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "2h",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "Windows2012_64",
       "guest_additions_mode": "disable",
@@ -127,7 +127,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "powershell",
@@ -143,7 +144,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "windows-shell",
@@ -170,6 +172,8 @@
     "iso_url": "https://software-download.microsoft.com/pr/en_windows_server_version_1709_x64_dvd_100090904.iso",
     "iso_checksum_type": "sha256",
     "iso_checksum": "ca1108d5be2c091bfb57e8f3db3be1e8baa9c32802131f7a6e43e63f7b596591",
-    "autounattend": "./answer_files/1709/Autounattend.xml"
+    "autounattend": "./answer_files/1709/Autounattend.xml",
+    "restart_timeout": "5m",
+    "winrm_timeout": "2h"
   }
 }


### PR DESCRIPTION
We're running packer builds via our CI server, which is sometimes quite busy. As a result the build often times out during reboots or initially waiting for WinRM.

Added user variables to allow the timeouts to be configured, so that we can wait longer if required.