### PR TITLE
Add vmx remove eth

### DIFF
--- a/windows_10.json
+++ b/windows_10.json
@@ -59,6 +59,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_10_docker.json
+++ b/windows_10_docker.json
@@ -14,6 +14,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_10_insider.json
+++ b/windows_10_insider.json
@@ -29,6 +29,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2008_r2.json
+++ b/windows_2008_r2.json
@@ -23,6 +23,7 @@
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2008_r2_core.json
+++ b/windows_2008_r2_core.json
@@ -11,7 +11,7 @@
     "ssh_wait_timeout": "2h",
     "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
     "guest_os_type": "windows7srv-64",
-	"tools_upload_flavor": "windows",
+	  "tools_upload_flavor": "windows",
     "disk_size": 61440,
     "vnc_port_min": 5900,
     "vnc_port_max": 5980,
@@ -20,6 +20,7 @@
       "./scripts/win-updates.ps1",
       "./scripts/openssh.ps1"
     ],
+    "vmx_remove_ethernet_interfaces": true,
     "vmx_data": {
       "RemoteDisplay.vnc.enabled": "false",
       "RemoteDisplay.vnc.port": "5900",

--- a/windows_2012.json
+++ b/windows_2012.json
@@ -22,6 +22,7 @@
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2012_r2.json
+++ b/windows_2012_r2.json
@@ -26,6 +26,7 @@
         "./scripts/unattend.xml",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2012_r2_core.json
+++ b/windows_2012_r2_core.json
@@ -23,6 +23,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2012_r2_hyperv.json
+++ b/windows_2012_r2_hyperv.json
@@ -22,6 +22,7 @@
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2016.json
+++ b/windows_2016.json
@@ -58,6 +58,7 @@
         "./scripts/sysprep.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2016_core.json
+++ b/windows_2016_core.json
@@ -51,6 +51,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2016_dc.json
+++ b/windows_2016_dc.json
@@ -52,6 +52,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -61,6 +61,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_2016_docker_core.json
+++ b/windows_2016_docker_core.json
@@ -1,11 +1,11 @@
 {
   "builders": [
     {
-      "vm_name": "WindowsServer2016CoreDocker",
+      "vm_name":"WindowsServer2016CoreDocker",
       "type": "hyperv-iso",
       "disk_size": 41440,
       "boot_wait": "0s",
-      "guest_additions_mode": "disable",
+      "guest_additions_mode":"disable",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -16,17 +16,16 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
-      "communicator": "winrm",
+      "communicator":"winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "{{user `winrm_timeout`}}",
-      "shutdown_command":
-        "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ram_size": 2048,
       "cpu": 2,
-      "switch_name": "{{user `hyperv_switchname`}}",
-      "enable_secure_boot": true,
-      "enable_virtualization_extensions": true
+      "switch_name":"{{user `hyperv_switchname`}}",
+      "enable_secure_boot":true,
+      "enable_virtualization_extensions":true
     },
     {
       "type": "vmware-iso",
@@ -38,9 +37,8 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "{{user `winrm_timeout`}}",
-      "shutdown_command":
-        "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows9srv-64",
       "disk_size": 61440,
       "vnc_port_min": 5900,
@@ -48,6 +46,7 @@
       "floppy_files": [
         "{{user `autounattend`}}",
         "./floppy/WindowsPowershell.lnk",
+        "./floppy/PinTo10.exe",
         "./scripts/disable-screensaver.ps1",
         "./scripts/disable-winrm.ps1",
         "./scripts/docker/enable-winrm.ps1",
@@ -74,9 +73,8 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "{{user `winrm_timeout`}}",
-      "shutdown_command":
-        "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "Windows2012_64",
       "guest_additions_mode": "disable",
       "disk_size": 61440,
@@ -88,19 +86,34 @@
         "./scripts/win-updates.ps1"
       ],
       "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--memory", "2048"],
-        ["modifyvm", "{{.Name}}", "--cpus", "2"]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "2"
+        ]
       ]
     }
   ],
   "provisioners": [
     {
       "type": "windows-shell",
-      "scripts": ["./scripts/vm-guest-tools.bat", "./scripts/enable-rdp.bat"]
+      "scripts": [
+        "./scripts/vm-guest-tools.bat",
+        "./scripts/enable-rdp.bat"
+      ]
     },
     {
       "type": "powershell",
-      "scripts": ["./scripts/debloat-windows.ps1"]
+      "scripts": [
+        "./scripts/debloat-windows.ps1"
+      ]
     },
     {
       "type": "windows-restart",
@@ -141,8 +154,7 @@
   ],
   "variables": {
     "headless": "false",
-    "iso_url":
-      "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
     "autounattend": "./answer_files/2016_core/Autounattend.xml",

--- a/windows_2016_docker_core.json
+++ b/windows_2016_docker_core.json
@@ -1,11 +1,11 @@
 {
   "builders": [
     {
-      "vm_name":"WindowsServer2016CoreDocker",
+      "vm_name": "WindowsServer2016CoreDocker",
       "type": "hyperv-iso",
       "disk_size": 41440,
       "boot_wait": "0s",
-      "guest_additions_mode":"disable",
+      "guest_additions_mode": "disable",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -16,16 +16,17 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
-      "communicator":"winrm",
+      "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "{{user `winrm_timeout`}}",
-      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "shutdown_command":
+        "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ram_size": 2048,
       "cpu": 2,
-      "switch_name":"{{user `hyperv_switchname`}}",
-      "enable_secure_boot":true,
-      "enable_virtualization_extensions":true
+      "switch_name": "{{user `hyperv_switchname`}}",
+      "enable_secure_boot": true,
+      "enable_virtualization_extensions": true
     },
     {
       "type": "vmware-iso",
@@ -37,8 +38,9 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "{{user `winrm_timeout`}}",
-      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "shutdown_command":
+        "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows9srv-64",
       "disk_size": 61440,
       "vnc_port_min": 5900,
@@ -46,7 +48,6 @@
       "floppy_files": [
         "{{user `autounattend`}}",
         "./floppy/WindowsPowershell.lnk",
-        "./floppy/PinTo10.exe",
         "./scripts/disable-screensaver.ps1",
         "./scripts/disable-winrm.ps1",
         "./scripts/docker/enable-winrm.ps1",
@@ -54,6 +55,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",
@@ -72,8 +74,9 @@
       "boot_wait": "2m",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "{{user `winrm_timeout`}}",
-      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "shutdown_command":
+        "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "Windows2012_64",
       "guest_additions_mode": "disable",
       "disk_size": 61440,
@@ -85,34 +88,19 @@
         "./scripts/win-updates.ps1"
       ],
       "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "2048"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "2"
-        ]
+        ["modifyvm", "{{.Name}}", "--memory", "2048"],
+        ["modifyvm", "{{.Name}}", "--cpus", "2"]
       ]
     }
   ],
   "provisioners": [
     {
       "type": "windows-shell",
-      "scripts": [
-        "./scripts/vm-guest-tools.bat",
-        "./scripts/enable-rdp.bat"
-      ]
+      "scripts": ["./scripts/vm-guest-tools.bat", "./scripts/enable-rdp.bat"]
     },
     {
       "type": "powershell",
-      "scripts": [
-        "./scripts/debloat-windows.ps1"
-      ]
+      "scripts": ["./scripts/debloat-windows.ps1"]
     },
     {
       "type": "windows-restart",
@@ -153,7 +141,8 @@
   ],
   "variables": {
     "headless": "false",
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
+    "iso_url":
+      "http://care.dlservice.microsoft.com/dl/download/1/4/9/149D5452-9B29-4274-B6B3-5361DBDA30BC/14393.0.161119-1705.RS1_REFRESH_SERVER_EVAL_X64FRE_EN-US.ISO",
     "iso_checksum_type": "md5",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
     "autounattend": "./answer_files/2016_core/Autounattend.xml",

--- a/windows_2016_hyperv.json
+++ b/windows_2016_hyperv.json
@@ -49,6 +49,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_7.json
+++ b/windows_7.json
@@ -23,6 +23,7 @@
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_81.json
+++ b/windows_81.json
@@ -22,6 +22,7 @@
         "./scripts/win-updates.ps1",
         "./scripts/openssh.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_server_1709.json
+++ b/windows_server_1709.json
@@ -58,6 +58,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_server_1709_docker.json
+++ b/windows_server_1709_docker.json
@@ -61,6 +61,7 @@
         "./scripts/microsoft-updates.bat",
         "./scripts/win-updates.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_server_insider.json
+++ b/windows_server_insider.json
@@ -51,6 +51,7 @@
         "./scripts/disable-winrm.ps1",
         "./scripts/enable-winrm.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",

--- a/windows_server_insider_docker.json
+++ b/windows_server_insider_docker.json
@@ -51,6 +51,7 @@
         "./scripts/disable-winrm.ps1",
         "./scripts/enable-winrm.ps1"
       ],
+      "vmx_remove_ethernet_interfaces": true,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900",


### PR DESCRIPTION
Add `vmx_remove_ethernet_interfaces` to VMware builder sections to avoid warnings during `vagrant up` like

```
==> 1709: Preparing network adapters...
WARNING: The VMX file for this box contains a setting that is automatically overwritten by Vagrant
WARNING: when started. Vagrant will stop overwriting this setting in an upcoming release which may
WARNING: prevent proper networking setup. Below is the detected VMX setting:
WARNING: 
WARNING:   ethernet0.pcislotnumber = "192"
WARNING: 
WARNING: If networking fails to properly configure, it may require this VMX setting. It can be manually
WARNING: applied via the Vagrantfile:
WARNING: 
WARNING:   Vagrant.configure(2) do |config|
WARNING:     config.vm.provider :vmare_fusion do |vmware|
WARNING:       vmware.vmx["ethernet0.pcislotnumber"] = "192"
WARNING:     end
WARNING:   end
WARNING: 
WARNING: For more information: https://www.vagrantup.com/docs/vmware/boxes.html#vmx-whitelisting
```
