### PR TITLE
Add vmware whitelist_verified = true flag

### DIFF
--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -42,6 +42,7 @@ Vagrant.configure("2") do |config|
         v.vmx["sound.present"] = "FALSE"
         v.vmx["sound.autodetect"] = "TRUE"
         v.enable_vmrun_ip_lookup = false
+        v.whitelist_verified = true
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -53,6 +54,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.enable_vmrun_ip_lookup = false
+        v.whitelist_verified = true
     end
 
     config.vm.provider "hyperv" do |v|

--- a/vagrantfile-windows_2008_r2.template
+++ b/vagrantfile-windows_2008_r2.template
@@ -33,6 +33,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -44,5 +45,6 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 end

--- a/vagrantfile-windows_2012.template
+++ b/vagrantfile-windows_2012.template
@@ -33,6 +33,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -44,5 +45,6 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 end

--- a/vagrantfile-windows_2012_r2.template
+++ b/vagrantfile-windows_2012_r2.template
@@ -33,6 +33,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -44,5 +45,6 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 end

--- a/vagrantfile-windows_2016.template
+++ b/vagrantfile-windows_2016.template
@@ -33,6 +33,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.enable_vmrun_ip_lookup = false
+        v.whitelist_verified = true
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -44,5 +45,6 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.enable_vmrun_ip_lookup = false
+        v.whitelist_verified = true
     end
 end

--- a/vagrantfile-windows_2016_docker.template
+++ b/vagrantfile-windows_2016_docker.template
@@ -43,6 +43,7 @@ Vagrant.configure("2") do |config|
         v.vmx["sound.autodetect"] = "TRUE"
         v.vms["virtualhw.version"] = "11"
         v.enable_vmrun_ip_lookup = false
+        v.whitelist_verified = true
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -54,6 +55,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.enable_vmrun_ip_lookup = false
+        v.whitelist_verified = true
     end
 
     config.vm.provider "hyperv" do |v|

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -33,6 +33,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -44,5 +45,6 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 end

--- a/vagrantfile-windows_81.template
+++ b/vagrantfile-windows_81.template
@@ -33,6 +33,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -44,5 +45,6 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
+        v.whitelist_verified = true
     end
 end


### PR DESCRIPTION
Follow-up to #55 as that first approach only helped for the first `vagrant up`. If you halt and up the machine again the warning still appears.
So fix it within the Vagrantfile template.