### PR TITLE
Fix windows_10 build

### DIFF
--- a/build_windows_10.sh
+++ b/build_windows_10.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 #packer build --only=vmware-iso windows_10.json
-packer build --only=vmware-iso windows_10.json
+#packer build --only=vmware-iso windows_10.json
 
 # Windows 10 Pro own license
 #packer build --only=vmware-iso --var iso_url=~/packer_cache/my/Win10_1607_English_x64.iso --var iso_checksum=99fd8082a609997ae97a514dca22becf20420891 --var autounattend=./tmp/10_pro/Autounattend.xml windows_10.json
 
 # Windows 10 Insider
 # packer build --only=vmware-iso --var iso_url=~/packer_cache/connect/16281.1000.170829-1438.rs3_release_CLIENT_BUSINESS_x64FRE_en-us.iso --var iso_checksum=1424eee844683d5e0206f94a034f3ddb80f13f65add5bf838c8608f247a99bd9 windows_10_insider.json
+# packer build --only=vmware-iso --var iso_url=~/packer_cache/connect/17025.1000.171020-1626.rs_prerelease_CLIENT_BUSINESS_VOL_x64FRE_en-us.iso --var iso_checksum=2ffc9daea950a2d43e0cafe4807870ce412cf1a9d24a94f6cf9240c71b4b8039 windows_10_insider.json
 
 # Windows 10 Enterprise MSDN
 #packer build --only=vmware-iso --var iso_url=~/packer_cache/msdn/en_windows_10_enterprise_version_1607_updated_jan_2017_x64_dvd_9714415.iso --var iso_checksum=97164DD5C1C933BAEF89A4BDE93D544256134FE4 --var iso_checksum_type=sha1 --var autounattend=./tmp/10/Autounattend.xml windows_10.json
@@ -18,3 +19,10 @@ packer build --only=vmware-iso windows_10.json
 #  --var iso_checksum=d35a1bc67c4cf0226a4e7381752e81a0ab081356 \
 #  --var autounattend=./tmp/10_pro_msdn/Autounattend.xml \
 #  windows_10.json
+
+packer build \
+  --only=vmware-iso \
+  --var disk_type_id=3 \
+  --var disk_size=30720 \
+  --var vhv_enable=true \
+  windows_10.json

--- a/scripts/debloat-windows.ps1
+++ b/scripts/debloat-windows.ps1
@@ -13,8 +13,11 @@ if ($env:PACKER_BUILDER_TYPE -And $($env:PACKER_BUILDER_TYPE).startsWith("hyperv
   #Write-Host Disable services
   #. $env:TEMP\Debloat-Windows-10-master\scripts\disable-services.ps1
   Write-host Disable Windows Defender
-  #. $env:TEMP\Debloat-Windows-10-master\scripts\disable-windows-defender.ps1
-  Uninstall-WindowsFeature Windows-Defender-Features
+  if ($(gp "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ProductName.StartsWith("Windows 10")) {
+    . $env:TEMP\Debloat-Windows-10-master\scripts\disable-windows-defender.ps1
+  } else {
+    Uninstall-WindowsFeature Windows-Defender-Features
+  }
   Write-host Optimize Windows Update
   . $env:TEMP\Debloat-Windows-10-master\scripts\optimize-windows-update.ps1
   #Write-host Disable Windows Update

--- a/windows_10.json
+++ b/windows_10.json
@@ -10,7 +10,7 @@
       "communicator":"winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout" : "4h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "ram_size": "2048",
       "cpu": "2",
       "switch_name": "{{user `switch_name`}}",
@@ -36,15 +36,16 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "6m",
       "boot_command": "",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "windows9-64",
       "disk_size": "{{user `disk_size`}}",
+      "disk_type_id": "{{user `disk_type_id`}}",
       "vnc_port_min": 5900,
       "vnc_port_max": 5980,
       "version": 11,
@@ -75,12 +76,12 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "headless": false,
+      "headless": "{{user `headless`}}",
       "boot_wait": "6m",
       "boot_command": "",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
-      "winrm_timeout": "2h",
+      "winrm_timeout" : "{{user `winrm_timeout`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "Windows10_64",
       "guest_additions_mode": "disable",
@@ -129,7 +130,8 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "{{user `restart_timeout`}}"
     },
     {
       "type": "powershell",
@@ -144,8 +146,9 @@
       "execute_command": "{{ .Vars }} cmd /c \"{{ .Path }}\"",
       "scripts": [
         "./scripts/pin-powershell.bat",
-        "./scripts/compile-dotnet-assemblies.bat",
         "./scripts/set-winrm-automatic.bat",
+        "./scripts/uac-enable.bat",
+        "./scripts/dis-updates.bat",
         "./scripts/compact.bat"
       ]
     }
@@ -159,10 +162,15 @@
     }
   ],
   "variables": {
+    "headless": "false",
+    "disk_size": "61440",
+    "disk_type_id": "1",
+    "vhv_enable": "false",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/6/5/D/65D18931-F626-4A35-AD5B-F5DA41FE6B76/16299.15.170928-1534.rs3_release_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "iso_checksum_type": "sha256",
     "iso_checksum": "3d39dd9bd37db5b3c80801ae44003802a9c770a7400a1b33027ca474a1a7c691",
     "autounattend": "./answer_files/10/Autounattend.xml",
-    "disk_size": "61440"
+    "restart_timeout": "5m",
+    "winrm_timeout": "6h"
   }
 }


### PR DESCRIPTION
* Remove the compile-dotnet-assemblies script as it crashes with Windows 10 Eval ISO.
* Add more variables in template
* Disable Windows Updates as this box is used like a Docker image and should be rebuilt after each Patch Tuesday

fixes #51 