### PR TITLE
Wait for TiWorker.exe

### DIFF
--- a/scripts/wait-for-tiworker.ps1
+++ b/scripts/wait-for-tiworker.ps1
@@ -1,0 +1,17 @@
+$procname="TiWorker"
+
+$finished = 0
+
+while ($finished -lt 3) {
+
+  Start-Sleep 30
+  Write-Output "Checking for $procname ($finished)"
+  $output = "$(get-process -erroraction silentlycontinue $procname)"
+  if ( $output -eq "") {
+    $finished = $finished + 1
+  } else {
+    $finished = 0
+  }
+
+}
+

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -147,6 +147,7 @@
         "./scripts/docker/add-docker-group.ps1",
         "./scripts/docker/install-docker.ps1",
         "./scripts/docker/docker-pull.ps1",
+        "./scripts/wait-for-tiworker.ps1",
         "./scripts/docker/open-docker-insecure-port.ps1",
         "./scripts/docker/open-docker-swarm-ports.ps1",
         "./scripts/docker/remove-docker-key-json.ps1",


### PR DESCRIPTION
During the last builds I have notices high CPU load during "docker pull".
Even after the win-updates script and rebooting for the next provision scripts Windows still starts a TiWorker.exe.

This is a workaround. Instead of debugging the win-updates scripts I found it easier to just wait for TiWorker until it no longer runs. 

```
    vmware-iso: Status: Downloaded newer image for microsoft/windowsservercore:latest
    vmware-iso: Installing microsoft/nanoserver ...
    vmware-iso: Running
    vmware-iso: Using default tag: latest
    vmware-iso: latest: Pulling from microsoft/nanoserver
    vmware-iso: Digest: sha256:3d2948c5af9f4bece59b13f199f5bec59d6dc4930fb15aa9b6a223d2ea8d8471
    vmware-iso: Status: Image is up to date for microsoft/nanoserver:latest
==> vmware-iso: Provisioning with powershell script: ./scripts/wait-for-tiworker.ps1
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (0)
    vmware-iso: Checking for TiWorker (1)
    vmware-iso: Checking for TiWorker (2)
==> vmware-iso: Provisioning with powershell script: ./scripts/docker/open-docker-insecure-port.ps1
```

Maybe we find out why the win-updates script no longer waits until all Windows updates have been installed.