### PR TITLE
Use Docker 17.10.0-ee-preview-3 to have npipe support

### DIFF
--- a/windows_server_1709_docker.json
+++ b/windows_server_1709_docker.json
@@ -174,7 +174,7 @@
     "disk_type_id": "1",
     "docker_images": "microsoft/windowsservercore:1709 microsoft/nanoserver:1709",
     "docker_provider": "DockerProvider",
-    "docker_version": "preview",
+    "docker_version": "17.10.0-ee-preview-3",
     "headless": "false",
     "iso_checksum": "ca1108d5be2c091bfb57e8f3db3be1e8baa9c32802131f7a6e43e63f7b596591",
     "iso_checksum_type": "sha256",


### PR DESCRIPTION
Pin Docker version to `17.10.0-ee-preview-3` instead of `preview` as latest preview installs 17.06.3-ee-1-tp6 that has no support to map npipe into containers.

I also tried `18.01.0-ee-1-tp5` but this version also complains 

```
$ docker run -v //./pipe/docker_engine://./pipe/docker_engine stefanscherer/docker-cli-windows docker version
docker: Error response from daemon: invalid bind mount spec "//./pipe/docker_engine://./pipe/docker_engine": invalid volume specification: '\\.\pipe\docker_engine:\\.\pipe\docker_engine'.
See 'docker run --help'.
```

So pin exactly to `17.10.0-ee-preview-3`
