### PR TITLE
ZeroDesktop: Disable VMware Shared Folders link on desktop

### DIFF
--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -45,6 +45,7 @@ Vagrant.configure("2") do |config|
         v.vmx["sound.autodetect"] = "TRUE"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -57,6 +58,7 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider "hyperv" do |v|

--- a/vagrantfile-windows_2008_r2.template
+++ b/vagrantfile-windows_2008_r2.template
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -48,5 +49,6 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 end

--- a/vagrantfile-windows_2012.template
+++ b/vagrantfile-windows_2012.template
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -48,5 +49,6 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 end

--- a/vagrantfile-windows_2012_r2.template
+++ b/vagrantfile-windows_2012_r2.template
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -48,5 +49,6 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 end

--- a/vagrantfile-windows_2016.template
+++ b/vagrantfile-windows_2016.template
@@ -46,6 +46,7 @@ Vagrant.configure("2") do |config|
         v.vms["virtualhw.version"] = "11"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -58,5 +59,6 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 end

--- a/vagrantfile-windows_2016_core.template
+++ b/vagrantfile-windows_2016_core.template
@@ -37,6 +37,7 @@ Vagrant.configure("2") do |config|
         v.vms["virtualhw.version"] = "11"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -49,6 +50,7 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider "hyperv" do |v|

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -48,5 +49,6 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 end

--- a/vagrantfile-windows_81.template
+++ b/vagrantfile-windows_81.template
@@ -36,6 +36,7 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -48,5 +49,6 @@ Vagrant.configure("2") do |config|
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
         v.vmx["gui.fitguestusingnativedisplayresolution"] = "FALSE"
         v.whitelist_verified = true
+        v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
 end


### PR DESCRIPTION
No more
<img width="117" alt="vmware-shared-folder-trash" src="https://user-images.githubusercontent.com/207759/35193835-038eae42-fea9-11e7-91c8-8d1c640141a0.png">

Disable the VMware Shared Folders desktop link to reach #ZeroDesktop.
