### PR TITLE
Re-add compile-dotnet-assemblies.bat

### DIFF
--- a/scripts/compile-dotnet-assemblies.bat
+++ b/scripts/compile-dotnet-assemblies.bat
@@ -6,10 +6,12 @@ if "%PROCESSOR_ARCHITECTURE%"=="AMD64" goto 64BIT
 %windir%\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue
 %windir%\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems
 
-exit /b
+exit 0
 
 :64BIT
 %windir%\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue
 %windir%\microsoft.net\framework64\v4.0.30319\ngen.exe update /force /queue
 %windir%\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems
 %windir%\microsoft.net\framework64\v4.0.30319\ngen.exe executequeueditems
+
+exit 0

--- a/windows_10.json
+++ b/windows_10.json
@@ -153,6 +153,7 @@
       "remote_path": "/tmp/script.bat",
       "scripts": [
         "./scripts/pin-powershell.bat",
+        "./scripts/compile-dotnet-assemblies.bat",
         "./scripts/set-winrm-automatic.bat",
         "./scripts/uac-enable.bat",
         "./scripts/dis-updates.bat",


### PR DESCRIPTION
Add `exit 0` to compile-dotnet-assemblies.bat to ignore the error on Windows 10 Enterprise Eval running `ngen.exe`.

Fixes #79 and #51 
