### PR TITLE
Use desktop image

### DIFF
--- a/build_windows_2019_docker.sh
+++ b/build_windows_2019_docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Insider ISO
+packer build \
+  --only=vmware-iso \
+  --var vhv_enable=true \
+  --var iso_url=~/packer_cache/insider/Windows_InsiderPreview_Server_vNext_en-us_17639.iso \
+  windows_2019_docker.json

--- a/windows_2019_docker.json
+++ b/windows_2019_docker.json
@@ -114,7 +114,7 @@
       "keep_input_artifact": false,
       "output": "windows_2019_docker_{{.Provider}}.box",
       "type": "vagrant",
-      "vagrantfile_template": "vagrantfile-windows_2016_core.template"
+      "vagrantfile_template": "vagrantfile-windows_2016.template"
     }
   ],
   "provisioners": [
@@ -167,7 +167,7 @@
     }
   ],
   "variables": {
-    "autounattend": "./answer_files/2019_core/Autounattend.xml",
+    "autounattend": "./answer_files/2019/Autounattend.xml",
     "disk_size": "61440",
     "disk_type_id": "1",
     "docker_images": "microsoft/windowsservercore microsoft/nanoserver",


### PR DESCRIPTION
Fix the `windows_2019_docker.json` to use desktop. Otherwise the build hangs:

<img width="1108" alt="bildschirmfoto 2018-04-12 um 19 21 32" src="https://user-images.githubusercontent.com/207759/38694033-e1eeeb60-3e88-11e8-8166-c0f08ac31e4d.png">
