### PR TITLE
add support for windows 2016 ami import with vbox

### DIFF
--- a/README-ami.md
+++ b/README-ami.md
@@ -5,7 +5,7 @@ the amazon import service https://docs.aws.amazon.com/vm-import/latest/userguide
 
 ## Requirements
 
-* Set your aws credentials on the default location `~/.aws/credentials`
-* Packer 1.2.3+
+* Set your aws credentials on the default location `~/.aws/credentials`. https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
+* Packer 1.2.3+. https://www.packer.io/downloads.html
 * S3 Bucket with the necessary permissions. Set the `AWS_S3_BUCKET` environment variable.
-* If you use SAML authentication make sure you set `profile` in the amazon-import post-processor
+* If you use SAML authentication make sure you set `profile` in the amazon-import post-processor.

--- a/README-ami.md
+++ b/README-ami.md
@@ -1,0 +1,11 @@
+## Windows - Amazon Import AMIs
+
+VirtualBox Hypervisor is used to build a local vm and then imported as an AMI using
+the amazon import service https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html.
+
+## Requirements
+
+* Set your aws credentials on the default location `~/.aws/credentials`
+* Packer 1.2.3+
+* S3 Bucket with the necessary permissions. Set the `AWS_S3_BUCKET` environment variable.
+* If you use SAML authentication make sure you set `profile` in the amazon-import post-processor

--- a/test.ps1
+++ b/test.ps1
@@ -8,6 +8,7 @@ $env:PACKER_AZURE_APP_ID="dummy"
 $env:PACKER_AZURE_CLIENT_SECRET="dummy"
 $env:PACKER_AZURE_RESOURCE_GROUP="dummy"
 $env:PACKER_AZURE_STORAGE_ACCOUNT="dummy"
+$env:AWS_S3_BUCKET="dummy"
 
 $files = @(Get-ChildItem *.json)
 

--- a/windows_2016_ami.json
+++ b/windows_2016_ami.json
@@ -21,6 +21,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
       "shutdown_command": "a:/sysprep.bat",
+      "format": "ova",
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/windows_2016_ami.json
+++ b/windows_2016_ami.json
@@ -1,0 +1,119 @@
+{
+  "builders": [
+   {
+      "boot_wait": "2m",
+      "communicator": "winrm",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/enable-winrm.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1",
+        "./scripts/unattend.xml",
+        "./scripts/sysprep.bat"
+      ],
+      "guest_additions_mode": "disable",
+      "guest_os_type": "Windows2016_64",
+      "headless": "{{user `headless`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "shutdown_command": "a:/sysprep.bat",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "2"
+        ]
+      ],
+      "vm_name": "WindowsServer2016",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    }
+  ],
+  "post-processors": [
+    {
+      "keep_input_artifact": false,
+      "output": "windows_2016_{{.Provider}}.box",
+      "type": "vagrant",
+      "vagrantfile_template": "vagrantfile-windows_2016.template"
+    },
+    {
+      "type": "amazon-import",
+      "only": ["virtualbox-iso"],
+      "access_key": "",
+      "secret_key": "",
+      "region": "",
+      "s3_bucket_name": "{{user `aws_s3_bucket_name`}}",
+      "keep_input_artifact": false,
+      "license_type": "BYOL",
+      "tags": 
+      {
+      "Description": "packer-windows amazon-import {{timestamp}}"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "{{ .Vars }} cmd /c \"{{ .Path }}\"",
+      "scripts": [
+        "./scripts/vm-guest-tools.bat",
+        "./scripts/enable-rdp.bat"
+      ],
+      "type": "windows-shell"
+    },
+    {
+      "scripts": [
+        "./scripts/debloat-windows.ps1"
+      ],
+      "type": "powershell"
+    },
+    {
+      "restart_timeout": "{{user `restart_timeout`}}",
+      "type": "windows-restart"
+    },
+    {
+      "execute_command": "{{ .Vars }} cmd /c \"{{ .Path }}\"",
+      "scripts": [
+        "./scripts/pin-powershell.bat",
+        "./scripts/set-winrm-automatic.bat",
+        "./scripts/uac-enable.bat",
+        "./scripts/compile-dotnet-assemblies.bat",
+        "./scripts/dis-updates.bat",
+        "./scripts/compact.bat"
+      ],
+      "type": "windows-shell"
+    },
+    {
+    "type": "powershell",
+    "inline": [ "C:/ProgramData/Amazon/EC2-Windows/Launch/Scripts/InitializeInstance.ps1 -Schedule",
+                "C:/ProgramData/Amazon/EC2-Windows/Launch/Scripts/SysprepInstance.ps1 -NoShutdown"
+              ]
+    }
+    ],
+  "variables": {
+    "autounattend": "./answer_files/2016/Autounattend.xml",
+    "disk_size": "61440",
+    "disk_type_id": "1",
+    "headless": "false",
+    "hyperv_switchname": "{{env `hyperv_switchname`}}",
+    "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
+    "iso_checksum_type": "md5",
+    "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
+    "restart_timeout": "5m",
+    "winrm_timeout": "4h",
+    "aws_s3_bucket_name": "{{env `AWS_S3_BUCKET`}}"
+  }
+}
+

--- a/windows_2016_ami.json
+++ b/windows_2016_ami.json
@@ -94,12 +94,6 @@
         "./scripts/compact.bat"
       ],
       "type": "windows-shell"
-    },
-    {
-    "type": "powershell",
-    "inline": [ "C:/ProgramData/Amazon/EC2-Windows/Launch/Scripts/InitializeInstance.ps1 -Schedule",
-                "C:/ProgramData/Amazon/EC2-Windows/Launch/Scripts/SysprepInstance.ps1 -NoShutdown"
-              ]
     }
     ],
   "variables": {
@@ -107,7 +101,6 @@
     "disk_size": "61440",
     "disk_type_id": "1",
     "headless": "false",
-    "hyperv_switchname": "{{env `hyperv_switchname`}}",
     "iso_checksum": "70721288BBCDFE3239D8F8C0FAE55F1F",
     "iso_checksum_type": "md5",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",


### PR DESCRIPTION
## Add support for vm import to amazon ami

* Remove other builders(this can be extended later)
* Use amazon import service to migrate a locally built virtual machine. https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html
* It uses a previous existing packer-windows configuration and added a `post-processor` configuration.