### PR TITLE
Run packer validate in Windows container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/windows-insider:10.0.17744.1001 AS makeiso
+WORKDIR C:/source
+COPY . .
+RUN powershell -NoProfile -ExecutionPolicy unrestricted -file make_unattend_iso.ps1
+
+FROM mcr.microsoft.com/windowsservercore-insider:10.0.17744.1001
+ENV chocolateyUseWindowsCompression false
+
+RUN powershell -NoProfile -ExecutionPolicy unrestricted -Command \
+    iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1')); \
+    choco feature disable --name showDownloadProgress
+RUN choco install -y packer
+RUN powershell -Command Install-WindowsFeature Hyper-V-PowerShell
+COPY --from=makeiso C:/source C:/source
+WORKDIR C:/source
+RUN powershell -File test.ps1

--- a/README-dockerfile.md
+++ b/README-dockerfile.md
@@ -1,0 +1,8 @@
+You may wander what's this `Dockerfile` for. I have tested the Windows Server 2019 insider 17744 build
+to see if I can run the `test.ps1` script that checks all packer templates with `packer validate` in a Windows container.
+
+```
+docker build -t packervalidate .
+```
+
+If the Docker image can be built then all packer templates have no errors.

--- a/README-dockerfile.md
+++ b/README-dockerfile.md
@@ -1,4 +1,4 @@
-You may wander what's this `Dockerfile` for. I have tested the Windows Server 2019 insider 17744 build
+You may wonder what's this `Dockerfile` for. I have tested the Windows Server 2019 insider 17744 build
 to see if I can run the `test.ps1` script that checks all packer templates with `packer validate` in a Windows container.
 
 ```


### PR DESCRIPTION
Add a `Dockerfile` to run the `packer validate` command for all Packer templates in an isolated environment.

I've used the latest Windows Server 2019 Insider 17744 build that allows to create the ISO files with the new full windows-insider image.

I had to use a multi-stage build as `Install-WindowsFeature` does not work in the full windows-insider image, but in the windowsservercore-insider image. In the second stage I install the Hyper-V PowerShell modules to validate the Hyper-V builder sections.

This Dockerfile and a Windows2019 VM with Docker allows me to run the Packer validate on my Mac.

FYI @PatrickLang  :-)
