### PR TITLE
Update Windows Server 2019 Docker image names

### DIFF
--- a/windows_2019_docker.json
+++ b/windows_2019_docker.json
@@ -170,7 +170,7 @@
     "autounattend": "./answer_files/2019_core/Autounattend.xml",
     "disk_size": "61440",
     "disk_type_id": "1",
-    "docker_images": "mcr.microsoft.com/nanoserver:sac2019 mcr.microsoft.com/windowsservercore:ltsc2019 mcr.microsoft.com/windows:ltsc2019",
+    "docker_images": "mcr.microsoft.com/windows/nanoserver:1809 mcr.microsoft.com/windows/servercore:ltsc2019",
     "docker_provider": "ee",
     "docker_version": "18-03-1-ee-3",
     "headless": "false",

--- a/windows_2019_docker_azure.json
+++ b/windows_2019_docker_azure.json
@@ -96,7 +96,7 @@
     "autounattend": "./answer_files/2019/Autounattend.xml",
     "disk_size": "51200",
     "disk_type_id": "1",
-    "docker_images": "mcr.microsoft.com/nanoserver:sac2019 mcr.microsoft.com/windowsservercore:ltsc2019 mcr.microsoft.com/windows:ltsc2019",
+    "docker_images": "mcr.microsoft.com/windows/nanoserver:1809 mcr.microsoft.com/windows/servercore:ltsc2019",
     "docker_provider": "ee",
     "docker_version": "18-03-1-ee-3",
     "headless": "false",


### PR DESCRIPTION
Phew. Hard to find the new Docker image names.
But I just found the image names

https://hub.docker.com/r/microsoft/nanoserver/ -> scroll down to 1809 and see the docker pull command

```
docker pull mcr.microsoft.com/windows/nanoserver:1809
```

The new tags are no longer pushed to Docker Hub, only to mcr.microsoft.com registry. But mcr.microsoft.com has no UI. That’s why the Docker Hub is used. It doesn’t feel like an optimal solution for users as it looks confusing to search with a different/old image name for the new correct pull command.


https://hub.docker.com/r/microsoft/windowsservercore/

```
docker pull mcr.microsoft.com/windows/servercore:ltsc2019
```

I haven’t found the correct image name for the new full Windows image yet.
