### PR TITLE
Update rsync.bat to latest version of rsync

### DIFF
--- a/scripts/rsync.bat
+++ b/scripts/rsync.bat
@@ -5,12 +5,12 @@ if not exist "C:\Windows\Temp\7z920-x64.msi" (
 msiexec /qb /i C:\Windows\Temp\7z920-x64.msi
 
 pushd C:\Windows\Temp
-powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://mirrors.kernel.org/sourceware/cygwin/x86_64/release/rsync/rsync-3.1.0-1.tar.xz', 'C:\Windows\Temp\rsync-3.1.0-1.tar.xz')" <NUL
-cmd /c ""C:\Program Files\7-Zip\7z.exe" x rsync-3.1.0-1.tar.xz"
-cmd /c ""C:\Program Files\7-Zip\7z.exe" x rsync-3.1.0-1.tar"
+powershell -Command "(New-Object System.Net.WebClient).DownloadFile('http://mirrors.kernel.org/sourceware/cygwin/x86_64/release/rsync/rsync-3.1.2-1.tar.xz', 'C:\Windows\Temp\rsync-3.1.2-1.tar.xz')" <NUL
+cmd /c ""C:\Program Files\7-Zip\7z.exe" x rsync-3.1.2-1.tar.xz"
+cmd /c ""C:\Program Files\7-Zip\7z.exe" x rsync-3.1.2-1.tar"
 copy /Y usr\bin\rsync.exe "C:\Program Files\OpenSSH\bin\rsync.exe"
 rmdir /s /q usr
-del rsync-3.1.0-1.tar
+del rsync-3.1.2-1.tar
 popd
 
 msiexec /qb /x C:\Windows\Temp\7z920-x64.msi


### PR DESCRIPTION
The version referenced in rsync.bat is no longer available for download as it is vulnerable to a bunch of CVEs.