### PR TITLE
Fix typo vms -> vmx

### DIFF
--- a/vagrantfile-windows_2016.template
+++ b/vagrantfile-windows_2016.template
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
         v.vmx["sound.startconnected"] = "FALSE"
         v.vmx["sound.present"] = "FALSE"
         v.vmx["sound.autodetect"] = "TRUE"
-        v.vms["virtualhw.version"] = "11"
+        v.vmx["virtualhw.version"] = "11"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
         v.vmx["hgfs.linkRootShare"] = "FALSE"

--- a/vagrantfile-windows_2016_core.template
+++ b/vagrantfile-windows_2016_core.template
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.enabled"] = "false"
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
-        v.vms["virtualhw.version"] = "11"
+        v.vmx["virtualhw.version"] = "11"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
         v.vmx["hgfs.linkRootShare"] = "FALSE"

--- a/vagrantfile-windows_2019_core.template
+++ b/vagrantfile-windows_2019_core.template
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.enabled"] = "false"
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
-        v.vms["virtualhw.version"] = "11"
+        v.vmx["virtualhw.version"] = "11"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
         v.vmx["hgfs.linkRootShare"] = "FALSE"


### PR DESCRIPTION
Fix typo in Vagrantfile templates: `v.vms` -> `v.vmx`
