### PR TITLE
Fix reboot loop, download updates again

### DIFF
--- a/scripts/win-updates.ps1
+++ b/scripts/win-updates.ps1
@@ -64,7 +64,7 @@ function Install-WindowsUpdates() {
     $CurrentUpdates = $SearchResult.Updates
     while($script:i -lt $CurrentUpdates.Count -and $script:CycleUpdateCount -lt $MaxUpdatesPerCycle) {
         $Update = $CurrentUpdates.Item($script:i)
-        if (($null -ne $Update) -and (!$Update.IsDownloaded)) {
+        if ($null -ne $Update) {
             [bool]$addThisUpdate = $false
             if ($Update.InstallationBehavior.CanRequestUserInput) {
                 LogWrite "> Skipping: $($Update.Title) because it requires user input"
@@ -165,13 +165,7 @@ function Install-WindowsUpdates() {
 function Check-WindowsUpdates() {
     LogWrite "Checking For Windows Updates"
     $Username = $env:USERDOMAIN + "\" + $env:USERNAME
-
-    New-EventLog -Source $ScriptName -LogName 'Windows Powershell' -ErrorAction SilentlyContinue
-
-    $Message = "Script: " + $ScriptPath + "`nScript User: " + $Username + "`nStarted: " + (Get-Date).toString()
-
-    Write-EventLog -LogName 'Windows Powershell' -Source $ScriptName -EventID "104" -EntryType "Information" -Message $Message
-    LogWrite $Message
+    LogWrite "Script: " + $ScriptPath + "`nScript User: " + $Username + "`nStarted: " + (Get-Date).toString()
 
     $script:UpdateSearcher = $script:UpdateSession.CreateUpdateSearcher()
     $script:successful = $FALSE


### PR DESCRIPTION

## first iteration:
<img width="1136" alt="windows_10-win-updates-start" src="https://user-images.githubusercontent.com/207759/50387310-24785500-06f9-11e9-8d76-14f2425d165e.png">

<img width="1136" alt="windows_10-win-updates-first-install" src="https://user-images.githubusercontent.com/207759/50387315-2f32ea00-06f9-11e9-8ab3-b71e539c0e87.png">

## after first reboot:

The `win-updates.ps1` script now downloads the updates again even if `$Update.IsDownloaded` tells us `$True`.

<img width="1136" alt="windows_10-win-updates-download-again" src="https://user-images.githubusercontent.com/207759/50387318-440f7d80-06f9-11e9-897c-8d673aa25b6e.png">

<img width="1136" alt="windows_10-win-updates-second-restart" src="https://user-images.githubusercontent.com/207759/50387320-52f63000-06f9-11e9-8b23-24a213a82604.png">

## after second reboot:
<img width="1136" alt="windows_10-win-updates-done" src="https://user-images.githubusercontent.com/207759/50387321-5ee1f200-06f9-11e9-983a-dca60aaffea3.png">


fixes #147 