### PR TITLE
Build Windows Server 2019 from MSDN ISOs with Hyper-V

### DIFF
--- a/answer_files/2019_core/Autounattend.xml
+++ b/answer_files/2019_core/Autounattend.xml
@@ -50,8 +50,8 @@
                 <OSImage>
                     <InstallFrom>
                         <MetaData wcm:action="add">
-                            <Key>/IMAGE/INDEX</Key>
-                            <Value>1</Value>
+                            <Key>/IMAGE/NAME</Key>
+                            <Value>Windows Server 2019 SERVERDATACENTER</Value>
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>

--- a/build_windows_2019_docker.ps1
+++ b/build_windows_2019_docker.ps1
@@ -1,0 +1,8 @@
+if (Test-Path ./output-hyperv-iso) {
+  Remove-Item -Recurse -Force ./output-hyperv-iso
+}
+
+packer build --only=hyperv-iso `
+             --var iso_url=./iso/en_windows_server_2019_x64_dvd_4cb967d8.iso `
+             --var iso_checksum="4C5DD63EFEE50117986A2E38D4B3A3FBAF3C1C15E2E7EA1D23EF9D8AF148DD2D" `
+             windows_2019_docker.json


### PR DESCRIPTION
The Windows Server 2019 trial is still delayed per https://cloudblogs.microsoft.com/windowsserver/2018/11/13/update-on-windows-server-2019-availability/

These are a few minor changes so that you can build using the MSDN ISO using Hyper-V. `2019_core/autounattend.xml` will also need `<Key>…</Key>` manually set before this will build. It should work with VMWare too but I haven't tested it.