### PR TITLE
Fix 2019 SERVERDATACENTERCORE

### DIFF
--- a/answer_files/2019_core/Autounattend.xml
+++ b/answer_files/2019_core/Autounattend.xml
@@ -51,7 +51,7 @@
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME</Key>
-                            <Value>Windows Server 2019 SERVERDATACENTER</Value>
+                            <Value>Windows Server 2019 SERVERDATACENTERCORE</Value>
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>

--- a/build_windows_2019_docker.sh
+++ b/build_windows_2019_docker.sh
@@ -3,6 +3,7 @@
 packer build \
   --only=vmware-iso \
   --var vhv_enable=true \
-  --var iso_url=~/downloads/17763.1.180914-1434.rs5_release_SERVER_EVAL_x64FRE_en-us.iso \
-  --var "docker_images=mcr.microsoft.com/nanoserver:sac2019 mcr.microsoft.com/windowsservercore:ltsc2019 mcr.microsoft.com/windows:ltsc2019" \
+  --var autounattend=./tmp/2019_core/Autounattend.xml \
+  --var iso_url=~/packer_cache/msdn/en_windows_server_2019_x64_dvd_4cb967d8.iso \
+  --var iso_checksum="4C5DD63EFEE50117986A2E38D4B3A3FBAF3C1C15E2E7EA1D23EF9D8AF148DD2D" \
   windows_2019_docker.json


### PR DESCRIPTION
- Switch back to Windows Server 2019 core edition in answer file.
- Update my build script to build from MSDN ISO.
