### PR TITLE
Update vmware virtualhw version 14

### DIFF
--- a/vagrantfile-windows_2016.template
+++ b/vagrantfile-windows_2016.template
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
         v.vmx["sound.startconnected"] = "FALSE"
         v.vmx["sound.present"] = "FALSE"
         v.vmx["sound.autodetect"] = "TRUE"
-        v.vmx["virtualhw.version"] = "11"
+        v.vmx["virtualhw.version"] = "14"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
         v.vmx["hgfs.linkRootShare"] = "FALSE"

--- a/vagrantfile-windows_2016_core.template
+++ b/vagrantfile-windows_2016_core.template
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.enabled"] = "false"
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
-        v.vmx["virtualhw.version"] = "11"
+        v.vmx["virtualhw.version"] = "14"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
         v.vmx["hgfs.linkRootShare"] = "FALSE"

--- a/vagrantfile-windows_2019_core.template
+++ b/vagrantfile-windows_2019_core.template
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.enabled"] = "false"
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsisas1068"
-        v.vmx["virtualhw.version"] = "11"
+        v.vmx["virtualhw.version"] = "14"
         v.enable_vmrun_ip_lookup = false
         v.whitelist_verified = true
         v.vmx["hgfs.linkRootShare"] = "FALSE"

--- a/windows_10.json
+++ b/windows_10.json
@@ -56,7 +56,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "windows_10",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_10_insider.json
+++ b/windows_10_insider.json
@@ -26,7 +26,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900"

--- a/windows_2016.json
+++ b/windows_2016.json
@@ -55,7 +55,7 @@
       "memory": 2048,
       "shutdown_command": "a:/sysprep.bat",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer2016",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -53,7 +53,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer2016Docker",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_2019.json
+++ b/windows_2019.json
@@ -55,7 +55,7 @@
       "memory": 2048,
       "shutdown_command": "a:/sysprep.bat",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer2019",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_2019_docker.json
+++ b/windows_2019_docker.json
@@ -53,7 +53,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer2019Docker",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_server_1709.json
+++ b/windows_server_1709.json
@@ -52,7 +52,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer1709",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_server_1709_docker.json
+++ b/windows_server_1709_docker.json
@@ -55,7 +55,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer1709Docker",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_server_1803.json
+++ b/windows_server_1803.json
@@ -52,7 +52,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer1803",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_server_1803_docker.json
+++ b/windows_server_1803_docker.json
@@ -55,7 +55,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer1803Docker",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_server_1809.json
+++ b/windows_server_1809.json
@@ -52,7 +52,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer1809",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_server_1809_docker.json
+++ b/windows_server_1809_docker.json
@@ -55,7 +55,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServer1809Docker",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_server_insider.json
+++ b/windows_server_insider.json
@@ -47,7 +47,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServerInsider",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",

--- a/windows_server_insider_docker.json
+++ b/windows_server_insider_docker.json
@@ -47,7 +47,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 12,
+      "version": 14,
       "vm_name": "WindowsServerInsiderDocker",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",


### PR DESCRIPTION
Update all newer templates to use the virtualhw.version 14 which is supported by VMware Workstation 12 / VMware Fusion 10.
