### PR TITLE
Update Windows Server Insider 18298

### DIFF
--- a/answer_files/server_insider/Autounattend.xml
+++ b/answer_files/server_insider/Autounattend.xml
@@ -51,7 +51,7 @@
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME</Key>
-                            <Value>Windows Server 2016 SERVERDATACENTERACORE</Value>
+                            <Value>Windows Server 2019 SERVERDATACENTERACORE</Value>
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>

--- a/build_windows_server_insider_docker.sh
+++ b/build_windows_server_insider_docker.sh
@@ -4,5 +4,5 @@
 PACKER_LOG=debug packer build \
   --only=vmware-iso \
   --var vhv_enable=true \
-  --var iso_url=~/packer_cache/insider/Windows_InsiderPreview_Server_17623.iso \
+  --var iso_url=~/packer_cache/insider/Windows_InsiderPreview_Server_en-us_18298.iso \
   windows_server_insider_docker.json

--- a/windows_server_insider.json
+++ b/windows_server_insider.json
@@ -28,6 +28,9 @@
       "winrm_username": "vagrant"
     },
     {
+      "boot_command": [
+        "<enter>"
+      ],
       "boot_wait": "60s",
       "communicator": "winrm",
       "cpus": 2,
@@ -62,6 +65,9 @@
       "winrm_username": "vagrant"
     },
     {
+      "boot_command": [
+        "<enter>"
+      ],
       "boot_wait": "60s",
       "communicator": "winrm",
       "cpus": 2,
@@ -123,9 +129,9 @@
     "disk_size": "61440",
     "disk_type_id": "1",
     "headless": "false",
-    "iso_checksum": "a4a8349a356d2d04219f417973d2a7576b35ab754cd30ad647d5e89d20890122",
+    "iso_checksum": "0dccf29961df59f55a637bb111729ae5123ea8ba63917424e40bd094100fc2b7",
     "iso_checksum_type": "sha256",
-    "iso_url": "https://software-download.microsoft.com/sg/Windows_InsiderPreview_Server_17692.iso",
+    "iso_url": "https://software-download.microsoft.com/sg/Windows_InsiderPreview_Server_en-us_18298.iso",
     "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
     "restart_timeout": "5m",
     "vhv_enable": "false",

--- a/windows_server_insider_docker.json
+++ b/windows_server_insider_docker.json
@@ -4,7 +4,7 @@
       "boot_command": [
         "<enter>"
       ],
-      "boot_wait": "1s",
+      "boot_wait": "60s",
       "communicator": "winrm",
       "cpu": 2,
       "disk_size": "{{user `disk_size`}}",
@@ -28,6 +28,9 @@
       "winrm_username": "vagrant"
     },
     {
+      "boot_command": [
+        "<enter>"
+      ],
       "boot_wait": "60s",
       "communicator": "winrm",
       "cpus": 2,
@@ -62,6 +65,9 @@
       "winrm_username": "vagrant"
     },
     {
+      "boot_command": [
+        "<enter>"
+      ],
       "boot_wait": "60s",
       "communicator": "winrm",
       "cpus": 2,
@@ -137,13 +143,14 @@
     "autounattend": "./answer_files/server_insider/Autounattend.xml",
     "disk_size": "61440",
     "disk_type_id": "1",
-    "docker_images": "microsoft/nanoserver-insider microsoft/windowsservercore-insider",
+    "old_docker_images": "microsoft/nanoserver-insider microsoft/windowsservercore-insider",
+    "docker_images": "",
     "docker_provider": "ee",
     "docker_version": "18-09-1",
     "headless": "false",
-    "iso_checksum": "a4a8349a356d2d04219f417973d2a7576b35ab754cd30ad647d5e89d20890122",
+    "iso_checksum": "0dccf29961df59f55a637bb111729ae5123ea8ba63917424e40bd094100fc2b7",
     "iso_checksum_type": "sha256",
-    "iso_url": "https://software-download.microsoft.com/pr/Windows_InsiderPreview_Server_17692.iso",
+    "iso_url": "https://software-download.microsoft.com/pr/Windows_InsiderPreview_Server_en-us_18298.iso",
     "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
     "restart_timeout": "5m",
     "vhv_enable": "true",


### PR DESCRIPTION
- Use boot_command to continue hanging autounattend process.
- Skip pulling any docker images as there seem to be no matching images
