### PR TITLE
Replaced depracated differencing_disk with linked_clone

### DIFF
--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -64,6 +64,6 @@ Vagrant.configure("2") do |config|
     config.vm.provider "hyperv" do |v|
         v.cpus = 2
         v.maxmemory = 2048
-        v.differencing_disk = true
+        v.linked_clone = true
     end
 end

--- a/vagrantfile-windows_2016_core.template
+++ b/vagrantfile-windows_2016_core.template
@@ -56,6 +56,6 @@ Vagrant.configure("2") do |config|
     config.vm.provider "hyperv" do |v|
         v.cpus = 2
         v.maxmemory = 2048
-        v.differencing_disk = true
+        v.linked_clone = true
     end
 end

--- a/vagrantfile-windows_2019_core.template
+++ b/vagrantfile-windows_2019_core.template
@@ -56,6 +56,6 @@ Vagrant.configure("2") do |config|
     config.vm.provider "hyperv" do |v|
         v.cpus = 2
         v.maxmemory = 2048
-        v.differencing_disk = true
+        v.linked_clone = true
     end
 end


### PR DESCRIPTION
Replaced depracated differencing_disk with linked_clone for Hyper-V in Vagrant configuration as it is now recommended in Vagrant documentation.

https://www.vagrantup.com/docs/hyperv/configuration.html