### PR TITLE
Updating Windows Server 2019 evaluation media and URL

### DIFF
--- a/build_windows_2019.sh
+++ b/build_windows_2019.sh
@@ -3,5 +3,5 @@
 packer build \
   --only=vmware-iso \
   --var vhv_enable=true \
-  --var iso_url=~/downloads/17763.1.180914-1434.rs5_release_SERVER_EVAL_x64FRE_en-us.iso \
+  --var iso_url=~/downloads/17763.379.190312-0539.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso \
   windows_2019.json

--- a/build_windows_2019_docker.ps1
+++ b/build_windows_2019_docker.ps1
@@ -3,6 +3,6 @@ if (Test-Path ./output-hyperv-iso) {
 }
 
 packer build --only=hyperv-iso `
-             --var iso_url=./iso/en_windows_server_2019_x64_dvd_4cb967d8.iso `
-             --var iso_checksum="4C5DD63EFEE50117986A2E38D4B3A3FBAF3C1C15E2E7EA1D23EF9D8AF148DD2D" `
+             --var iso_url=./iso/17763.379.190312-0539.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso `
+             --var iso_checksum="221F9ACBC727297A56674A0F1722B8AC7B6E840B4E1FFBDD538A9ED0DA823562" `
              windows_2019_docker.json

--- a/windows_2019.json
+++ b/windows_2019.json
@@ -144,10 +144,10 @@
     "disk_type_id": "1",
     "headless": "false",
     "hyperv_switchname": "{{env `hyperv_switchname`}}",
-    "iso_checksum": "57FAF4A2EA4484CFDF5E964C539313C061C4D9CAC474E723D60405F2EA02D570",
+    "iso_checksum": "221F9ACBC727297A56674A0F1722B8AC7B6E840B4E1FFBDD538A9ED0DA823562",
     "iso_checksum_type": "sha256",
-    "iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
+    "iso_url": "https://software-download.microsoft.com/download/sg/17763.379.190312-0539.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+    "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019",
     "restart_timeout": "5m",
     "winrm_timeout": "2h"
   }

--- a/windows_2019_core.json
+++ b/windows_2019_core.json
@@ -126,10 +126,10 @@
     "disk_size": "61440",
     "disk_type_id": "1",
     "headless": "false",
-    "iso_checksum": "57FAF4A2EA4484CFDF5E964C539313C061C4D9CAC474E723D60405F2EA02D570",
+    "iso_checksum": "221F9ACBC727297A56674A0F1722B8AC7B6E840B4E1FFBDD538A9ED0DA823562",
     "iso_checksum_type": "sha256",
-    "iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
+    "iso_url": "https://software-download.microsoft.com/download/sg/17763.379.190312-0539.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+    "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019",
     "winrm_timeout": "6h"
   }
 }

--- a/windows_2019_core_ami.json
+++ b/windows_2019_core_ami.json
@@ -90,10 +90,10 @@
     "disk_size": "61440",
     "disk_type_id": "1",
     "headless": "false",
-    "iso_checksum": "57FAF4A2EA4484CFDF5E964C539313C061C4D9CAC474E723D60405F2EA02D570",
+    "iso_checksum": "221F9ACBC727297A56674A0F1722B8AC7B6E840B4E1FFBDD538A9ED0DA823562",
     "iso_checksum_type": "sha256",
-    "iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
+    "iso_url": "https://software-download.microsoft.com/download/sg/17763.379.190312-0539.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+    "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019",
     "winrm_timeout": "6h"
   }
 }

--- a/windows_2019_docker.json
+++ b/windows_2019_docker.json
@@ -162,10 +162,10 @@
     "docker_provider": "ee",
     "docker_version": "18-09-1",
     "headless": "false",
-    "iso_checksum": "57FAF4A2EA4484CFDF5E964C539313C061C4D9CAC474E723D60405F2EA02D570",
+    "iso_checksum": "221F9ACBC727297A56674A0F1722B8AC7B6E840B4E1FFBDD538A9ED0DA823562",
     "iso_checksum_type": "sha256",
-    "iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
+    "iso_url": "https://software-download.microsoft.com/download/sg/17763.379.190312-0539.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+    "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019",
     "restart_timeout": "5m",
     "vhv_enable": "false",
     "winrm_timeout": "6h"

--- a/windows_2019_docker_azure.json
+++ b/windows_2019_docker_azure.json
@@ -101,10 +101,10 @@
     "docker_version": "18-09-1",
     "headless": "false",
     "hyperv_switchname": "{{env `hyperv_switchname`}}",
-    "iso_checksum": "57FAF4A2EA4484CFDF5E964C539313C061C4D9CAC474E723D60405F2EA02D570",
+    "iso_checksum": "221F9ACBC727297A56674A0F1722B8AC7B6E840B4E1FFBDD538A9ED0DA823562",
     "iso_checksum_type": "sha256",
-    "iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "manually_download_iso_from": "https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewserver",
+    "iso_url": "https://software-download.microsoft.com/download/sg/17763.379.190312-0539.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+    "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019",
     "restart_timeout": "5m",
     "winrm_timeout": "2h"
   }


### PR DESCRIPTION
The evaluation media was updated with more patches included in March. Moving to the new ISO means less time is needed to apply updates :)