### PR TITLE
Clarify Hyper-V Virtual Switch Name to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ only have Hyper-V installed on my laptop, so I run:
 packer build --only hyperv-iso -var 'hyperv_switchname=Ethernet' -var 'iso_url=./server2016.iso' .\windows_2016_docker.json
 ```
 
-You then can use this box with Vagrant to spin up a Hyper-V VM.
+Where `Ethernet` is the name of my default Hyper-V Virtual Switch. You then can use this box with Vagrant to spin up a Hyper-V VM.
 
 #### Generation 2 VMs
 


### PR DESCRIPTION
When I was using the instructions to create a Hyper-V box I used the switch name `Ethernet` as is in the examples because I actually thought that was something to be used internally to the Packer box. 

Looking at it now it's clear it's not but I just wanted to add this little bit to hopefully clear up any confusion for people in the future.