### PR TITLE
Set Hyper-V VM version 8.0

### DIFF
--- a/windows_10.json
+++ b/windows_10.json
@@ -3,6 +3,7 @@
     {
       "boot_wait": "6m",
       "communicator": "winrm",
+      "configuration_version": "8.0",
       "cpus": "2",
       "disk_size": "{{user `disk_size`}}",
       "floppy_files": [

--- a/windows_2016.json
+++ b/windows_2016.json
@@ -3,6 +3,7 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",
       "enable_secure_boot": true,

--- a/windows_2016_core.json
+++ b/windows_2016_core.json
@@ -3,6 +3,7 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",
       "enable_secure_boot": true,

--- a/windows_2016_docker.json
+++ b/windows_2016_docker.json
@@ -3,6 +3,7 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",
       "enable_secure_boot": true,

--- a/windows_2016_hyperv.json
+++ b/windows_2016_hyperv.json
@@ -3,6 +3,7 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",
       "enable_secure_boot": true,

--- a/windows_2019.json
+++ b/windows_2019.json
@@ -3,6 +3,7 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",
       "enable_secure_boot": true,

--- a/windows_2019_core.json
+++ b/windows_2019_core.json
@@ -3,6 +3,7 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",
       "enable_secure_boot": true,

--- a/windows_2019_docker.json
+++ b/windows_2019_docker.json
@@ -3,6 +3,7 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",
       "enable_secure_boot": true,


### PR DESCRIPTION
Create the Hyper-V boxes more compatible for older host OS versions.

https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/deploy/upgrade-virtual-machine-version-in-hyper-v-on-windows-or-windows-server#supported-vm-configuration-versions-for-long-term-servicing-hosts

Set VM version "8.0" to be compatible with Windows Server 2016 hosts.
