### PR TITLE
Update Windows 7 scripts to use WinRM

### DIFF
--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -2,32 +2,6 @@
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <servicing/>
     <settings pass="windowsPE">
-        <component name="Microsoft-Windows-PnpCustomizationsWinPE"
-            publicKeyToken="31bf3856ad364e35" language="neutral"
-            versionScope="nonSxS" processorArchitecture="amd64"
-            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
-
-            <!--
-                 This makes the VirtIO drivers available to Windows, assuming that
-                 the VirtIO driver disk
-                 (https://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/)
-                 is available as drive E:
-            -->
-            <DriverPaths>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-                    <Path>E:\amd64\w7\</Path>
-                </PathAndCredentials>
-
-                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-                    <Path>E:\viostor\w7\amd64</Path>
-                </PathAndCredentials>
-
-                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                    <Path>E:\NetKVM\w7\amd64</Path>
-                </PathAndCredentials>
-            </DriverPaths>
-        </component>
-
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DiskConfiguration>
                 <Disk wcm:action="add">

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -2,6 +2,32 @@
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <servicing/>
     <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE"
+            publicKeyToken="31bf3856ad364e35" language="neutral"
+            versionScope="nonSxS" processorArchitecture="amd64"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+            <!--
+                 This makes the VirtIO drivers available to Windows, assuming that
+                 the VirtIO driver disk
+                 (https://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/)
+                 is available as drive E:
+            -->
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+                    <Path>E:\amd64\w7\</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+                    <Path>E:\viostor\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+                    <Path>E:\NetKVM\w7\amd64</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DiskConfiguration>
                 <Disk wcm:action="add">
@@ -60,11 +86,11 @@
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
             </SetupUILanguage>
-            <InputLocale>de-DE</InputLocale>
-            <SystemLocale>de-DE</SystemLocale>
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
             <UILanguage>en-US</UILanguage>
             <UILanguageFallback>en-US</UILanguageFallback>
-            <UserLocale>de-DE</UserLocale>
+            <UserLocale>en-US</UserLocale>
         </component>
     </settings>
     <settings pass="offlineServicing">
@@ -120,81 +146,9 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm quickconfig -q</CommandLine>
-                    <Description>winrm quickconfig -q</Description>
-                    <Order>3</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm quickconfig -transport:http</CommandLine>
-                    <Description>winrm quickconfig -transport:http</Description>
-                    <Order>4</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
-                    <Description>Win RM MaxTimoutms</Description>
+                    <CommandLine>C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\disable-winrm.ps1</CommandLine>
+                    <Description>Disable WinRM</Description>
                     <Order>5</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
-                    <Description>Win RM MaxMemoryPerShellMB</Description>
-                    <Order>6</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
-                    <Description>Win RM AllowUnencrypted</Description>
-                    <Order>7</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
-                    <Description>Win RM auth Basic</Description>
-                    <Order>8</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
-                    <Description>Win RM client auth Basic</Description>
-                    <Order>9</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c winrm set winrm/config/listener?Address=*+Transport=HTTP @{Port="5985"} </CommandLine>
-                    <Description>Win RM listener Address/Port</Description>
-                    <Order>10</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes </CommandLine>
-                    <Description>Win RM adv firewall enable</Description>
-                    <Order>11</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
-                    <Description>Win RM port open</Description>
-                    <Order>12</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c net stop winrm </CommandLine>
-                    <Description>Stop Win RM Service </Description>
-                    <Order>13</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
-                    <Description>Win RM Autostart</Description>
-                    <Order>14</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c net start winrm</CommandLine>
-                    <Description>Start Win RM Service</Description>
-                    <Order>15</Order>
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
@@ -241,10 +195,9 @@
                     <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1 -AutoStart</CommandLine>
-                    <Description>Install OpenSSH</Description>
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\enable-winrm.ps1</CommandLine>
+                    <Description>Enable WinRM</Description>
                     <Order>99</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
                 </SynchronousCommand>
                 -->
                 <!-- END WITHOUT WINDOWS UPDATES -->

--- a/windows_7.json
+++ b/windows_7.json
@@ -117,7 +117,7 @@
     }
   ],
   "variables": {
-    "winrm_timeout": "6h",
+    "winrm_timeout": "6h"
   }
 }
 

--- a/windows_7.json
+++ b/windows_7.json
@@ -7,37 +7,6 @@
       "winrm_timeout": "{{user `winrm_timeout`}}",
       "winrm_username": "vagrant",
       "cpus": 2,
-      "disk_size": 61440,
-      "floppy_files": [
-        "./answer_files/7/Autounattend.xml",
-        "./scripts/dis-updates.ps1",
-        "./scripts/microsoft-updates.bat",
-        "./scripts/win-updates.ps1"
-      ],
-      "headless": true,
-      "iso_checksum": "1d0d239a252cb53e466d39e752b17c28",
-      "iso_checksum_type": "md5",
-      "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
-      "memory": 2048,
-      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-      "ssh_password": "vagrant",
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "8h",
-      "type": "qemu",
-      "accelerator": "kvm",
-      "output_directory": "windows_7-qemu",
-      "qemuargs": [
-        [ "-drive", "file=windows_7-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1" ],
-        [ "-drive", "file={{ user `virtio_win_iso` }},media=cdrom,index=3" ]
-      ]
-    },
-    {
-      "boot_wait": "2m",
-      "communicator": "winrm",
-      "winrm_password": "vagrant",
-      "winrm_timeout": "{{user `winrm_timeout`}}",
-      "winrm_username": "vagrant",
-      "cpus": 2,
       "disk_adapter_type": "lsisas1068",
       "disk_size": 61440,
       "floppy_files": [
@@ -149,7 +118,6 @@
   ],
   "variables": {
     "winrm_timeout": "6h",
-    "virtio_win_iso": "/home/quamotion/git/packer-windows/virtio-win.iso"
   }
 }
 

--- a/windows_7.json
+++ b/windows_7.json
@@ -2,6 +2,41 @@
   "builders": [
     {
       "boot_wait": "2m",
+      "communicator": "winrm",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant",
+      "cpus": 2,
+      "disk_size": 61440,
+      "floppy_files": [
+        "./answer_files/7/Autounattend.xml",
+        "./scripts/dis-updates.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "headless": true,
+      "iso_checksum": "1d0d239a252cb53e466d39e752b17c28",
+      "iso_checksum_type": "md5",
+      "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+      "memory": 2048,
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "8h",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "output_directory": "windows_7-qemu",
+      "qemuargs": [
+        [ "-drive", "file=windows_7-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1" ],
+        [ "-drive", "file={{ user `virtio_win_iso` }},media=cdrom,index=3" ]
+      ]
+    },
+    {
+      "boot_wait": "2m",
+      "communicator": "winrm",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant",
       "cpus": 2,
       "disk_adapter_type": "lsisas1068",
       "disk_size": 61440,
@@ -9,8 +44,7 @@
         "./answer_files/7/Autounattend.xml",
         "./scripts/dis-updates.ps1",
         "./scripts/microsoft-updates.bat",
-        "./scripts/win-updates.ps1",
-        "./scripts/openssh.ps1"
+        "./scripts/win-updates.ps1"
       ],
       "guest_os_type": "windows7-64",
       "headless": false,
@@ -34,14 +68,17 @@
     },
     {
       "boot_wait": "2m",
+      "communicator": "winrm",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant",
       "cpus": 2,
       "disk_size": 61440,
       "floppy_files": [
         "./answer_files/7/Autounattend.xml",
         "./scripts/dis-updates.ps1",
         "./scripts/microsoft-updates.bat",
-        "./scripts/win-updates.ps1",
-        "./scripts/openssh.ps1"
+        "./scripts/win-updates.ps1"
       ],
       "guest_os_type": "Windows7_64",
       "headless": false,
@@ -98,20 +135,21 @@
   ],
   "provisioners": [
     {
-      "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c C:/tmp/script.bat",
       "remote_path": "/tmp/script.bat",
       "scripts": [
         "./scripts/vm-guest-tools.bat",
-        "./scripts/chef.bat",
-        "./scripts/vagrant-ssh.bat",
+        "./scripts/disable-auto-logon.bat",
         "./scripts/enable-rdp.bat",
-        "./scripts/enable-winrm.bat",
-        "./scripts/disable-tasks.bat",
         "./scripts/compile-dotnet-assemblies.bat",
         "./scripts/compact.bat"
       ],
-      "type": "shell"
+      "type": "windows-shell"
     }
-  ]
+  ],
+  "variables": {
+    "winrm_timeout": "6h",
+    "virtio_win_iso": "/home/quamotion/git/packer-windows/virtio-win.iso"
+  }
 }
 


### PR DESCRIPTION
### What this PR does
This PR updates the windows 7 scripts and updates them so that they use WinRM instead of SSH (which was broken, because the `win-updates.ps` script doesn't install SSH anymore).

It brings the script more in line with other Windows versions

Fixes include
- Setting the local to en-US instead of de-DE
- Use `enable-winrm.ps1`/`win-updates.ps1` to enable WinRM instead of individual steps in Autounattended.xml
- Change the provisioner from `shell` to `windows-shell`.

I have validated this using qemu/KVM (the first commit includes the qemu-related changes, the second commit undoes them, you'll want to squash merge).

### Why this PR is needed
We use Vagrant boxes for CI testing of our software. Windows 7 is still a supported (and massively used) baseline, so we're looking for a recent Vagrant box which includes Windows 7.

Unfortunately, the most popular Windows 7 boxes on Vagrant Atlas are all 4 to 5 years old. So we're looking for a new base box we can use.