### PR TITLE
Add QEMU/KVM support for Windows 10, Windows 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,22 @@ hyperv-iso output will be in this color.
 * Secondary Dvd image does not exist: CreateFile ./iso/windows_server_insider_unattend.iso: The system cannot find the file specified.
 ```
 
+### KVM/qemu support
+
+If you are using Linux and have KVM/qemu configured, you can use these packerfiles to build a KVM virtual machine.
+To build a KVM/qemu box, first make sure:
+
+* You are a member of the kvm group on your machine. You can list the groups you are member of by running `groups`. It should
+  include the `kvm` group. If you're not a member, run `sudo usermod -aG kvm $(whoami)` to add yourself.
+* You have downloaded [the iso image with the Windows drivers for paravirtualized KVM/qemu hardware](wget -nv -nc https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso).
+  You can do this from the command line: `wget -nv -nc https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso -O virtio-win.iso`.
+
+You can use the following sample command to build a KVM/qemu box:
+
+```
+packer build --only=qemu --var virtio_win_iso=./virtio-win.iso ./windows_2019_docker.json
+```
+
 ### Using .box Files With Vagrant
 
 The generated box files include a Vagrantfile template that is suitable for use

--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -9,17 +9,53 @@
 
             <!--
                  This makes the VirtIO drivers available to Windows, assuming that
-                 the VirtIO driver disk
-                 (https://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/)
+                 the VirtIO driver disk at https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso
+                 (see https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html#virtio-win-direct-downloads)
                  is available as drive E:
             -->
             <DriverPaths>
                 <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-                    <Path>E:\viostor\w7\amd64</Path>
+                    <Path>E:\viostor\w10\amd64</Path>
                 </PathAndCredentials>
 
                 <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                    <Path>E:\NetKVM\w7\amd64</Path>
+                    <Path>E:\NetKVM\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+                    <Path>E:\Balloon\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5">
+                    <Path>E:\pvpanic\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6">
+                    <Path>E:\qemupciserial\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7">
+                    <Path>E:\qxldod\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8">
+                    <Path>E:\vioinput\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9">
+                    <Path>E:\viorng\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10">
+                    <Path>E:\vioscsi\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11">
+                    <Path>E:\vioserial\w10\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12">
+                    <Path>E:\vioserial\w10\amd64</Path>
                 </PathAndCredentials>
             </DriverPaths>
         </component>

--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -53,10 +53,6 @@
                 <PathAndCredentials wcm:action="add" wcm:keyValue="11">
                     <Path>E:\vioserial\w10\amd64</Path>
                 </PathAndCredentials>
-
-                <PathAndCredentials wcm:action="add" wcm:keyValue="12">
-                    <Path>E:\vioserial\w10\amd64</Path>
-                </PathAndCredentials>
             </DriverPaths>
         </component>
         

--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -2,6 +2,28 @@
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <servicing/>
     <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE"
+            publicKeyToken="31bf3856ad364e35" language="neutral"
+            versionScope="nonSxS" processorArchitecture="amd64"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+            <!--
+                 This makes the VirtIO drivers available to Windows, assuming that
+                 the VirtIO driver disk
+                 (https://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/)
+                 is available as drive E:
+            -->
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+                    <Path>E:\viostor\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+                    <Path>E:\NetKVM\w7\amd64</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+        
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DiskConfiguration>
                 <Disk wcm:action="add">

--- a/answer_files/2019/Autounattend.xml
+++ b/answer_files/2019/Autounattend.xml
@@ -1,6 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE"
+            publicKeyToken="31bf3856ad364e35" language="neutral"
+            versionScope="nonSxS" processorArchitecture="amd64"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+            <!--
+                 This makes the VirtIO drivers available to Windows, assuming that
+                 the VirtIO driver disk
+                 (https://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/)
+                 is available as drive E:
+            -->
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+                    <Path>E:\viostor\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+                    <Path>E:\NetKVM\w7\amd64</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>

--- a/answer_files/2019/Autounattend.xml
+++ b/answer_files/2019/Autounattend.xml
@@ -52,10 +52,6 @@
                 <PathAndCredentials wcm:action="add" wcm:keyValue="11">
                     <Path>E:\vioserial\2k19\amd64</Path>
                 </PathAndCredentials>
-
-                <PathAndCredentials wcm:action="add" wcm:keyValue="12">
-                    <Path>E:\vioserial\2k19\amd64</Path>
-                </PathAndCredentials>
             </DriverPaths>
         </component>
 

--- a/answer_files/2019/Autounattend.xml
+++ b/answer_files/2019/Autounattend.xml
@@ -8,17 +8,53 @@
 
             <!--
                  This makes the VirtIO drivers available to Windows, assuming that
-                 the VirtIO driver disk
-                 (https://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/)
+                 the VirtIO driver disk at https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso
+                 (see https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html#virtio-win-direct-downloads)
                  is available as drive E:
             -->
             <DriverPaths>
                 <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-                    <Path>E:\viostor\w7\amd64</Path>
+                    <Path>E:\viostor\2k19\amd64</Path>
                 </PathAndCredentials>
 
                 <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                    <Path>E:\NetKVM\w7\amd64</Path>
+                    <Path>E:\NetKVM\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+                    <Path>E:\Balloon\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5">
+                    <Path>E:\pvpanic\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6">
+                    <Path>E:\qemupciserial\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7">
+                    <Path>E:\qxldod\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8">
+                    <Path>E:\vioinput\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9">
+                    <Path>E:\viorng\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10">
+                    <Path>E:\vioscsi\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11">
+                    <Path>E:\vioserial\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12">
+                    <Path>E:\vioserial\2k19\amd64</Path>
                 </PathAndCredentials>
             </DriverPaths>
         </component>

--- a/answer_files/2019_core/Autounattend.xml
+++ b/answer_files/2019_core/Autounattend.xml
@@ -52,10 +52,6 @@
                 <PathAndCredentials wcm:action="add" wcm:keyValue="11">
                     <Path>E:\vioserial\2k19\amd64</Path>
                 </PathAndCredentials>
-
-                <PathAndCredentials wcm:action="add" wcm:keyValue="12">
-                    <Path>E:\vioserial\2k19\amd64</Path>
-                </PathAndCredentials>
             </DriverPaths>
         </component>
 

--- a/answer_files/2019_core/Autounattend.xml
+++ b/answer_files/2019_core/Autounattend.xml
@@ -1,6 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE"
+            publicKeyToken="31bf3856ad364e35" language="neutral"
+            versionScope="nonSxS" processorArchitecture="amd64"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+            <!--
+                 This makes the VirtIO drivers available to Windows, assuming that
+                 the VirtIO driver disk
+                 (https://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/)
+                 is available as drive E:
+            -->
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+                    <Path>E:\viostor\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+                    <Path>E:\NetKVM\w7\amd64</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>

--- a/answer_files/2019_core/Autounattend.xml
+++ b/answer_files/2019_core/Autounattend.xml
@@ -8,17 +8,53 @@
 
             <!--
                  This makes the VirtIO drivers available to Windows, assuming that
-                 the VirtIO driver disk
-                 (https://alt.fedoraproject.org/pub/alt/virtio-win/latest/images/bin/)
+                 the VirtIO driver disk at https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso
+                 (see https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html#virtio-win-direct-downloads)
                  is available as drive E:
             -->
             <DriverPaths>
                 <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-                    <Path>E:\viostor\w7\amd64</Path>
+                    <Path>E:\viostor\2k19\amd64</Path>
                 </PathAndCredentials>
 
                 <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                    <Path>E:\NetKVM\w7\amd64</Path>
+                    <Path>E:\NetKVM\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+                    <Path>E:\Balloon\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5">
+                    <Path>E:\pvpanic\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6">
+                    <Path>E:\qemupciserial\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7">
+                    <Path>E:\qxldod\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8">
+                    <Path>E:\vioinput\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9">
+                    <Path>E:\viorng\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10">
+                    <Path>E:\vioscsi\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11">
+                    <Path>E:\vioserial\2k19\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12">
+                    <Path>E:\vioserial\2k19\amd64</Path>
                 </PathAndCredentials>
             </DriverPaths>
         </component>

--- a/scripts/vm-guest-tools.bat
+++ b/scripts/vm-guest-tools.bat
@@ -9,6 +9,7 @@ msiexec /qb /i C:\Windows\Temp\7z1900-x64.msi
 if "%PACKER_BUILDER_TYPE%" equ "vmware-iso" goto :vmware
 if "%PACKER_BUILDER_TYPE%" equ "virtualbox-iso" goto :virtualbox
 if "%PACKER_BUILDER_TYPE%" equ "parallels-iso" goto :parallels
+if "%PACKER_BUILDER_TYPE%" equ "qemu" goto :qemu
 goto :done
 
 :vmware
@@ -54,6 +55,12 @@ if exist "C:\Users\vagrant\prl-tools-win.iso" (
 	cmd /C "C:\Program Files\7-Zip\7z.exe" x C:\Windows\Temp\prl-tools-win.iso -oC:\Windows\Temp\parallels
 	cmd /C C:\Windows\Temp\parallels\PTAgent.exe /install_silent
 	rd /S /Q "C:\Windows\Temp\parallels"
+)
+goto :done
+
+:qemu
+if exist "E:\guest-agent\" (
+    msiexec /qb /x E:\guest-agent\qemu-ga-x86_64.msi
 )
 
 :done

--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -67,8 +67,25 @@ Vagrant.configure("2") do |config|
         v.linked_clone = true
     end
     
-    config.vm.provider :libvirt do |libvirt|
+    config.vm.provider :libvirt do |libvirt, override|
         libvirt.memory = 2048
         libvirt.cpus = 2
+
+        # Use WinRM for the default synced folder; or disable it if
+        # WinRM is not available. Linux hosts don't support SMB,
+        # and Windows guests don't support NFS/9P/rsync
+        # See https://github.com/Cimpress-MCP/vagrant-winrm-syncedfolders
+        if Vagrant.has_plugin?("vagrant-winrm-syncedfolders")
+            override.vm.synced_folder ".", "/vagrant", type: "winrm"
+        else
+            override.vm.synced_folder ".", "/vagrant", disabled: true
+        end
+
+        # Enable Hyper-V enlightments, see
+        # https://blog.wikichoon.com/2014/07/enabling-hyper-v-enlightenments-with-kvm.html
+        libvirt.hyperv_feature :name => 'stimer',  :state => 'on'
+        libvirt.hyperv_feature :name => 'relaxed', :state => 'on'
+        libvirt.hyperv_feature :name => 'vapic',   :state => 'on'
+        libvirt.hyperv_feature :name => 'synic',   :state => 'on'
     end
 end

--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -66,4 +66,9 @@ Vagrant.configure("2") do |config|
         v.maxmemory = 2048
         v.linked_clone = true
     end
+    
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.memory = 2048
+        libvirt.cpus = 2
+    end
 end

--- a/vagrantfile-windows_2016.template
+++ b/vagrantfile-windows_2016.template
@@ -62,8 +62,25 @@ Vagrant.configure("2") do |config|
         v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
     
-    config.vm.provider :libvirt do |libvirt|
+    config.vm.provider :libvirt do |libvirt, override|
         libvirt.memory = 2048
         libvirt.cpus = 2
+
+        # Use WinRM for the default synced folder; or disable it if
+        # WinRM is not available. Linux hosts don't support SMB,
+        # and Windows guests don't support NFS/9P/rsync
+        # See https://github.com/Cimpress-MCP/vagrant-winrm-syncedfolders
+        if Vagrant.has_plugin?("vagrant-winrm-syncedfolders")
+            override.vm.synced_folder ".", "/vagrant", type: "winrm"
+        else
+            override.vm.synced_folder ".", "/vagrant", disabled: true
+        end
+
+        # Enable Hyper-V enlightments, see
+        # https://blog.wikichoon.com/2014/07/enabling-hyper-v-enlightenments-with-kvm.html
+        libvirt.hyperv_feature :name => 'stimer',  :state => 'on'
+        libvirt.hyperv_feature :name => 'relaxed', :state => 'on'
+        libvirt.hyperv_feature :name => 'vapic',   :state => 'on'
+        libvirt.hyperv_feature :name => 'synic',   :state => 'on'
     end
 end

--- a/vagrantfile-windows_2016.template
+++ b/vagrantfile-windows_2016.template
@@ -61,4 +61,9 @@ Vagrant.configure("2") do |config|
         v.whitelist_verified = true
         v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
+    
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.memory = 2048
+        libvirt.cpus = 2
+    end
 end

--- a/vagrantfile-windows_2019_core.template
+++ b/vagrantfile-windows_2019_core.template
@@ -58,4 +58,9 @@ Vagrant.configure("2") do |config|
         v.maxmemory = 2048
         v.linked_clone = true
     end
+    
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.memory = 2048
+        libvirt.cpus = 2
+    end
 end

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -52,8 +52,25 @@ Vagrant.configure("2") do |config|
         v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
     
-    config.vm.provider :libvirt do |libvirt|
+    config.vm.provider :libvirt do |libvirt, override|
         libvirt.memory = 2048
         libvirt.cpus = 2
+
+        # Use WinRM for the default synced folder; or disable it if
+        # WinRM is not available. Linux hosts don't support SMB,
+        # and Windows guests don't support NFS/9P/rsync
+        # See https://github.com/Cimpress-MCP/vagrant-winrm-syncedfolders
+        if Vagrant.has_plugin?("vagrant-winrm-syncedfolders")
+            override.vm.synced_folder ".", "/vagrant", type: "winrm"
+        else
+            override.vm.synced_folder ".", "/vagrant", disabled: true
+        end
+
+        # Enable Hyper-V enlightments, see
+        # https://blog.wikichoon.com/2014/07/enabling-hyper-v-enlightenments-with-kvm.html
+        libvirt.hyperv_feature :name => 'stimer',  :state => 'on'
+        libvirt.hyperv_feature :name => 'relaxed', :state => 'on'
+        libvirt.hyperv_feature :name => 'vapic',   :state => 'on'
+        libvirt.hyperv_feature :name => 'synic',   :state => 'on'
     end
 end

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -51,4 +51,9 @@ Vagrant.configure("2") do |config|
         v.whitelist_verified = true
         v.vmx["hgfs.linkRootShare"] = "FALSE"
     end
+    
+    config.vm.provider :libvirt do |libvirt|
+        libvirt.memory = 2048
+        libvirt.cpus = 2
+    end
 end

--- a/windows_10.json
+++ b/windows_10.json
@@ -3,6 +3,40 @@
     {
       "boot_wait": "6m",
       "communicator": "winrm",
+      "cpus": "2",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./floppy/WindowsPowershell.lnk",
+        "./floppy/PinTo10.exe",
+        "./scripts/fixnetwork.ps1",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/enable-winrm.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "headless": true,
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": "2048",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "output_directory": "windows_10-qemu",
+      "qemuargs": [
+        [ "-drive", "file=windows_10-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1" ],
+        [ "-drive", "file={{ user `virtio_win_iso` }},media=cdrom,index=3" ]
+      ],
+      "vm_name": "windows_10",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    },
+    {
+      "boot_wait": "6m",
+      "communicator": "winrm",
       "configuration_version": "8.0",
       "cpus": "2",
       "disk_size": "{{user `disk_size`}}",
@@ -161,7 +195,8 @@
     "iso_url": "https://software-download.microsoft.com/download/pr/18362.30.190401-1528.19h1_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "restart_timeout": "5m",
     "vhv_enable": "false",
-    "winrm_timeout": "6h"
+    "winrm_timeout": "6h",
+    "virtio_win_iso": "~/virtio-win.iso"
   }
 }
 

--- a/windows_2019.json
+++ b/windows_2019.json
@@ -3,6 +3,39 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "cpus": 2,
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/enable-winrm.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/unattend.xml",
+        "./scripts/sysprep.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "headless": true,
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": 2048,
+      "shutdown_command": "a:/sysprep.bat",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "output_directory": "windows_2019-qemu",
+      "qemuargs": [
+        [ "-drive", "file=windows_2019-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1" ],
+        [ "-drive", "file={{ user `virtio_win_iso` }},media=cdrom,index=3" ]
+      ],
+      "vm_name": "WindowsServer2019",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    },
+    {
+      "boot_wait": "0s",
+      "communicator": "winrm",
       "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",
@@ -150,7 +183,8 @@
     "iso_url": "https://software-download.microsoft.com/download/sg/17763.379.190312-0539.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
     "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019",
     "restart_timeout": "5m",
-    "winrm_timeout": "2h"
+    "winrm_timeout": "2h",
+    "virtio_win_iso": "~/virtio-win.iso"
   }
 }
 

--- a/windows_2019_docker.json
+++ b/windows_2019_docker.json
@@ -3,6 +3,38 @@
     {
       "boot_wait": "0s",
       "communicator": "winrm",
+      "cpus": 2,
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/docker/enable-winrm.ps1",
+        "./scripts/docker/2016/install-containers-feature.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "headless": true,
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": 2048,
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "output_directory": "windows_2019_docker-qemu",
+      "qemuargs": [
+        [ "-drive", "file=windows_2019_docker-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1" ],
+        [ "-drive", "file={{ user `virtio_win_iso` }},media=cdrom,index=3" ]
+      ],
+      "vm_name": "WindowsServer2019Docker",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    },
+    {
+      "boot_wait": "0s",
+      "communicator": "winrm",
       "configuration_version": "8.0",
       "cpus": 2,
       "disk_size": "{{user `disk_size`}}",


### PR DESCRIPTION
This PR adds QEMU/KVM support for Windows 10, Windows 2019 images:

- Adds qemu provisioners. They also mount the `virt-win.iso` image, which contains the virtio drivers & agent
- Injects the virtio drivers (for paravirtualized storage and networking) via `Autounattend.xml`. 
- Adds support for installing the qemu agent in `vm_guest_tools.bat`
- Updates the default Vagrantfile to:
  * Set CPU, memory defaults for libvirt (2 GB/2 CPUs)
  * Enbable Hyper-V enlightment features
  * Disable the default synced folder, unless the vagrant-winrm-syncedfolders plugin is installed, in which case the synced folder will use winrm