### PR TITLE
Windows 7: Manually install SP1, Servicing Stack Update,  Update Rollup & Cumulative Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,25 @@ uncommenting the `WITHOUT WINDOWS UPDATES` section in `Autounattend.xml`:
 
 Doing so will give you hours back in your day, which is a good thing.
 
+### Windows 7 support
+
+Windows 7 is going out of support in January 2020, and the scripts for building Windows 7 machines are only
+sporadically maintained.
+
+Windows 7 was first released in 2009. This means there are a lot of updates available for Windows 7,
+and running Windows Updates on a Windows 7 box using the mechanism described above takes an extremely long time.
+
+The Windows 7 templates therefore take a slightly different approach, first installing Service Pack 1,
+updating the servicing stack and then installing the latest update rollup, .NET 4.8 and PowerShell 5.1.
+Finally, any missing updates are installed using Ansible.
+
+This means you'll need to install Ansible on your machine if you want to run the Windows 7 scripts.
+You can [install ansible on a Linux machine](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html).
+
+If you want to run these scripts on a Windows machine, you can try to run Ansible in cygwin or Bash on Ubuntu on Windows.
+Alternatively, you can disable the `ansible` steps in the `windows_7.json` file. Make sure to manually run
+Windows Update if you do!
+
 ### WinRM
 
 These boxes use WinRM. There is no OpenSSH installed.

--- a/ansible/connection_plugins/packer.py
+++ b/ansible/connection_plugins/packer.py
@@ -1,0 +1,218 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.connection.ssh import Connection as SSHConnection
+
+DOCUMENTATION = '''
+    connection: packer
+    short_description: ssh based connections for powershell via packer
+    description:
+        - This connection plugin allows ansible to communicate to the target packer machines via ssh based connections for powershell.
+    author: Packer Community
+    version_added: na
+    options:
+      host:
+          description: Hostname/ip to connect to.
+          default: inventory_hostname
+          vars:
+               - name: ansible_host
+               - name: ansible_ssh_host
+      host_key_checking:
+          description: Determines if ssh should check host keys
+          type: boolean
+          ini:
+              - section: defaults
+                key: 'host_key_checking'
+              - section: ssh_connection
+                key: 'host_key_checking'
+                version_added: '2.5'
+          env:
+              - name: ANSIBLE_HOST_KEY_CHECKING
+              - name: ANSIBLE_SSH_HOST_KEY_CHECKING
+                version_added: '2.5'
+          vars:
+              - name: ansible_host_key_checking
+                version_added: '2.5'
+              - name: ansible_ssh_host_key_checking
+                version_added: '2.5'
+      password:
+          description: Authentication password for the C(remote_user). Can be supplied as CLI option.
+          vars:
+              - name: ansible_password
+              - name: ansible_ssh_pass
+      ssh_args:
+          description: Arguments to pass to all ssh cli tools
+          default: '-C -o ControlMaster=auto -o ControlPersist=60s'
+          ini:
+              - section: 'ssh_connection'
+                key: 'ssh_args'
+          env:
+              - name: ANSIBLE_SSH_ARGS
+      ssh_common_args:
+          description: Common extra args for all ssh CLI tools
+          vars:
+              - name: ansible_ssh_common_args
+      ssh_executable:
+          default: ssh
+          description:
+            - This defines the location of the ssh binary. It defaults to ``ssh`` which will use the first ssh binary available in $PATH.
+            - This option is usually not required, it might be useful when access to system ssh is restricted,
+              or when using ssh wrappers to connect to remote hosts.
+          env: [{name: ANSIBLE_SSH_EXECUTABLE}]
+          ini:
+          - {key: ssh_executable, section: ssh_connection}
+          #const: ANSIBLE_SSH_EXECUTABLE
+          version_added: "2.2"
+      sftp_executable:
+          default: sftp
+          description:
+            - This defines the location of the sftp binary. It defaults to ``sftp`` which will use the first binary available in $PATH.
+          env: [{name: ANSIBLE_SFTP_EXECUTABLE}]
+          ini:
+          - {key: sftp_executable, section: ssh_connection}
+          version_added: "2.6"
+      scp_executable:
+          default: scp
+          description:
+            - This defines the location of the scp binary. It defaults to `scp` which will use the first binary available in $PATH.
+          env: [{name: ANSIBLE_SCP_EXECUTABLE}]
+          ini:
+          - {key: scp_executable, section: ssh_connection}
+          version_added: "2.6"
+      scp_extra_args:
+          description: Extra exclusive to the ``scp`` CLI
+          vars:
+              - name: ansible_scp_extra_args
+      sftp_extra_args:
+          description: Extra exclusive to the ``sftp`` CLI
+          vars:
+              - name: ansible_sftp_extra_args
+      ssh_extra_args:
+          description: Extra exclusive to the 'ssh' CLI
+          vars:
+              - name: ansible_ssh_extra_args
+      retries:
+          # constant: ANSIBLE_SSH_RETRIES
+          description: Number of attempts to connect.
+          default: 3
+          type: integer
+          env:
+            - name: ANSIBLE_SSH_RETRIES
+          ini:
+            - section: connection
+              key: retries
+            - section: ssh_connection
+              key: retries
+      port:
+          description: Remote port to connect to.
+          type: int
+          default: 22
+          ini:
+            - section: defaults
+              key: remote_port
+          env:
+            - name: ANSIBLE_REMOTE_PORT
+          vars:
+            - name: ansible_port
+            - name: ansible_ssh_port
+      remote_user:
+          description:
+              - User name with which to login to the remote server, normally set by the remote_user keyword.
+              - If no user is supplied, Ansible will let the ssh client binary choose the user as it normally
+          ini:
+            - section: defaults
+              key: remote_user
+          env:
+            - name: ANSIBLE_REMOTE_USER
+          vars:
+            - name: ansible_user
+            - name: ansible_ssh_user
+      pipelining:
+          default: ANSIBLE_PIPELINING
+          description:
+            - Pipelining reduces the number of SSH operations required to execute a module on the remote server,
+              by executing many Ansible modules without actual file transfer.
+            - This can result in a very significant performance improvement when enabled.
+            - However this conflicts with privilege escalation (become).
+              For example, when using sudo operations you must first disable 'requiretty' in the sudoers file for the target hosts,
+              which is why this feature is disabled by default.
+          env:
+            - name: ANSIBLE_PIPELINING
+            #- name: ANSIBLE_SSH_PIPELINING
+          ini:
+            - section: defaults
+              key: pipelining
+            #- section: ssh_connection
+            #  key: pipelining
+          type: boolean
+          vars:
+            - name: ansible_pipelining
+            - name: ansible_ssh_pipelining
+      private_key_file:
+          description:
+              - Path to private key file to use for authentication
+          ini:
+            - section: defaults
+              key: private_key_file
+          env:
+            - name: ANSIBLE_PRIVATE_KEY_FILE
+          vars:
+            - name: ansible_private_key_file
+            - name: ansible_ssh_private_key_file
+      control_path:
+        description:
+          - This is the location to save ssh's ControlPath sockets, it uses ssh's variable substitution.
+          - Since 2.3, if null, ansible will generate a unique hash. Use `%(directory)s` to indicate where to use the control dir path setting.
+        env:
+          - name: ANSIBLE_SSH_CONTROL_PATH
+        ini:
+          - key: control_path
+            section: ssh_connection
+      control_path_dir:
+        default: ~/.ansible/cp
+        description:
+          - This sets the directory to use for ssh control path if the control path setting is null.
+          - Also, provides the `%(directory)s` variable for the control path setting.
+        env:
+          - name: ANSIBLE_SSH_CONTROL_PATH_DIR
+        ini:
+          - section: ssh_connection
+            key: control_path_dir
+      sftp_batch_mode:
+        default: 'yes'
+        description: 'TODO: write it'
+        env: [{name: ANSIBLE_SFTP_BATCH_MODE}]
+        ini:
+        - {key: sftp_batch_mode, section: ssh_connection}
+        type: bool
+      scp_if_ssh:
+        default: smart
+        description:
+          - "Prefered method to use when transfering files over ssh"
+          - When set to smart, Ansible will try them until one succeeds or they all fail
+          - If set to True, it will force 'scp', if False it will use 'sftp'
+        env: [{name: ANSIBLE_SCP_IF_SSH}]
+        ini:
+        - {key: scp_if_ssh, section: ssh_connection}
+      use_tty:
+        version_added: '2.5'
+        default: 'yes'
+        description: add -tt to ssh commands to force tty allocation
+        env: [{name: ANSIBLE_SSH_USETTY}]
+        ini:
+        - {key: usetty, section: ssh_connection}
+        type: bool
+        yaml: {key: connection.usetty}
+'''
+
+class Connection(SSHConnection):
+    ''' ssh based connections for powershell via packer'''
+
+    transport = 'packer'
+    has_pipelining = True
+    become_methods = []
+    allow_executable = False
+    module_implementation_preferences = ('.ps1', '')
+
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__(*args, **kwargs)

--- a/ansible/windows_update.yml
+++ b/ansible/windows_update.yml
@@ -1,0 +1,9 @@
+- hosts: all
+  tasks:
+  - name: Install only security updates
+    win_updates:
+      category_names:
+      - SecurityUpdates
+      - CriticalUpdates
+      - UpdateRollups
+      use_scheduled_task: yes

--- a/ansible/windows_update_security_updates.yml
+++ b/ansible/windows_update_security_updates.yml
@@ -1,0 +1,7 @@
+- hosts: all
+  tasks:
+  - name: Install only security updates
+    win_updates:
+      category_names:
+      - SecurityUpdates
+      use_scheduled_task: yes

--- a/answer_files/7/Autounattend.xml
+++ b/answer_files/7/Autounattend.xml
@@ -2,6 +2,64 @@
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <servicing/>
     <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE"
+            publicKeyToken="31bf3856ad364e35" language="neutral"
+            versionScope="nonSxS" processorArchitecture="amd64"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+
+            <!--
+                 This makes the VirtIO drivers available to Windows, assuming that
+                 the VirtIO driver disk at https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso
+                 (see https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html#virtio-win-direct-downloads)
+                 is available as drive E:
+            -->
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+                    <Path>E:\viostor\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+                    <Path>E:\NetKVM\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4">
+                    <Path>E:\Balloon\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5">
+                    <Path>E:\pvpanic\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6">
+                    <Path>E:\qemupciserial\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7">
+                    <Path>E:\qxl\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8">
+                    <Path>E:\vioinput\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9">
+                    <Path>E:\viorng\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10">
+                    <Path>E:\vioscsi\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11">
+                    <Path>E:\vioserial\w7\amd64</Path>
+                </PathAndCredentials>
+
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12">
+                    <Path>K:\kaboom\w7\amd64</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DiskConfiguration>
                 <Disk wcm:action="add">
@@ -160,8 +218,6 @@
                     <Order>22</Order>
                     <Description>Disable password expiration for vagrant user</Description>
                 </SynchronousCommand>
-                <!-- WITHOUT WINDOWS UPDATES -->
-                <!--
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\dis-updates.ps1</CommandLine>
                     <Description>Disable Automatic Updates</Description>
@@ -173,22 +229,6 @@
                     <Description>Enable WinRM</Description>
                     <Order>99</Order>
                 </SynchronousCommand>
-                -->
-                <!-- END WITHOUT WINDOWS UPDATES -->
-                <!-- WITH WINDOWS UPDATES -->
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\dis-updates.ps1</CommandLine>
-                    <Description>Disable Automatic Updates</Description>
-                    <Order>97</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1 -MaxUpdatesPerCycle 30</CommandLine>
-                    <Description>Install Windows Updates</Description>
-                    <Order>100</Order>
-                    <RequiresUserInput>true</RequiresUserInput>
-                </SynchronousCommand>
-                <!-- END WITH WINDOWS UPDATES -->
             </FirstLogonCommands>
             <ShowWindowsLive>false</ShowWindowsLive>
         </component>

--- a/scripts/chocolatey.bat
+++ b/scripts/chocolatey.bat
@@ -1,1 +1,1 @@
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" <NUL
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"

--- a/scripts/chocopacks.bat
+++ b/scripts/chocopacks.bat
@@ -1,6 +1,8 @@
 :: Ensure C:\Chocolatey\bin is on the path
-set /p PATH=<C:\Windows\Temp\PATH
+set /p PATH=%PATH%;C:\ProgramData\chocolatey\
+echo %PATH%
 
 :: Install all the things; for example:
-cmd /c choco install 7zip
-cmd /c choco install notepadplusplus
+choco install /y 7zip
+choco install /y notepadplusplus
+choco install /y boxstarter.winconfig

--- a/scripts/enable-winrm.bat
+++ b/scripts/enable-winrm.bat
@@ -1,2 +1,3 @@
 rem Enable-NetFirewallRule for WinRM
 netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985
+sc.exe config winrm start= auto

--- a/scripts/win-7-update-2016-convenience-rollup.ps1
+++ b/scripts/win-7-update-2016-convenience-rollup.ps1
@@ -1,0 +1,16 @@
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+Write-Host "$(Get-Date -Format G): Downloading Convenience rollup update for Windows 7"
+(New-Object Net.WebClient).DownloadFile("http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/05/windows6.1-kb3125574-v4-x64_2dafb1d203c8964239af3048b5dd4b1264cd93b9.msu", "C:\Updates\windows6.1-kb3125574-v4-x64.msu")
+
+$kbid="windows6.1-kb3125574-v4-x64"
+$update="Convenience rollup update for Windows 7"
+
+Write-Host "$(Get-Date -Format G): Extracting $update"
+Start-Process -FilePath "wusa.exe" -ArgumentList "C:\Updates\$kbid.msu /extract:C:\Updates" -Wait
+
+Write-Host "$(Get-Date -Format G): Installing $update"
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\$kbid.cab /quiet /norestart /LogPath:C:\Windows\Temp\$kbid.log" -Wait
+
+Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+Write-Host "$(Get-Date -Format G): Finished installing $update. The VM will now reboot and continue the installation process."

--- a/scripts/win-7-update-2019-03-servicing-stack.ps1
+++ b/scripts/win-7-update-2019-03-servicing-stack.ps1
@@ -1,0 +1,16 @@
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+Write-Host "$(Get-Date -Format G): Downloading March 2019 Servicing Stack Update for Windows 7"
+(New-Object Net.WebClient).DownloadFile("http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/03/windows6.1-kb4490628-x64_d3de52d6987f7c8bdc2c015dca69eac96047c76e.msu", "C:\Updates\windows6.1-kb4490628-x64.msu")
+
+$kbid="windows6.1-KB4490628-x64"
+$update="March 2019 Servicing Stack Update for Windows 7"
+
+Write-Host "$(Get-Date -Format G): Extracting $update"
+Start-Process -FilePath "wusa.exe" -ArgumentList "C:\Updates\$kbid.msu /extract:C:\Updates" -Wait
+
+Write-Host "$(Get-Date -Format G): Installing $update"
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\$kbid.cab /quiet /norestart /LogPath:C:\Windows\Temp\$kbid.log" -Wait
+
+Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+Write-Host "$(Get-Date -Format G): Finished installing $update. The VM will now reboot and continue the installation process."

--- a/scripts/win-7-update-2019-07-update-rollup.ps1
+++ b/scripts/win-7-update-2019-07-update-rollup.ps1
@@ -1,0 +1,16 @@
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+Write-Host "$(Get-Date -Format G): Downloading July 2019 Update Rollup for Windows 7"
+(New-Object Net.WebClient).DownloadFile("http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/06/windows6.1-kb4507449-x64_6e41f8e0642fb3a87e99b8acd34b7541b9316d0b.msu", "C:\Updates\windows6.1-kb4507449-x64.msu")
+
+$kbid="windows6.1-kb4507449-x64"
+$update="July 2019 Update Rollup for Windows 7"
+
+Write-Host "$(Get-Date -Format G): Extracting $update"
+Start-Process -FilePath "wusa.exe" -ArgumentList "C:\Updates\$kbid.msu /extract:C:\Updates" -Wait
+
+Write-Host "$(Get-Date -Format G): Installing $update"
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\$kbid.cab /quiet /norestart /LogPath:C:\Windows\Temp\$kbid.log" -Wait
+
+Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+Write-Host "$(Get-Date -Format G): Finished installing $update. The VM will now reboot and continue the installation process."

--- a/scripts/win-7-update-2019-09-servicing-stack.ps1
+++ b/scripts/win-7-update-2019-09-servicing-stack.ps1
@@ -1,0 +1,16 @@
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+Write-Host "$(Get-Date -Format G): Downloading September 2019 Servicing Stack Update for Windows 7"
+(New-Object Net.WebClient).DownloadFile("http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/09/windows6.1-kb4516655-x64_8acf6b3aeb8ebb79973f034c39a9887c9f7df812.msu", "C:\Updates\windows6.1-kb4516655-x64.msu")
+
+$kbid="windows6.1-kb4516655-x64"
+$update="September 2019 Servicing Stack Update for Windows 7"
+
+Write-Host "$(Get-Date -Format G): Extracting $update"
+Start-Process -FilePath "wusa.exe" -ArgumentList "C:\Updates\$kbid.msu /extract:C:\Updates" -Wait
+
+Write-Host "$(Get-Date -Format G): Installing $update"
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\$kbid.cab /quiet /norestart /LogPath:C:\Windows\Temp\$kbid.log" -Wait
+
+Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+Write-Host "$(Get-Date -Format G): Finished installing $update. The VM will now reboot and continue the installation process."

--- a/scripts/win-7-update-2019-09-sha2.ps1
+++ b/scripts/win-7-update-2019-09-sha2.ps1
@@ -1,0 +1,16 @@
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+Write-Host "$(Get-Date -Format G): Downloading September 2019 SHA2 Update"
+(New-Object Net.WebClient).DownloadFile("http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/09/windows6.1-kb4474419-v3-x64_b5614c6cea5cb4e198717789633dca16308ef79c.msu", "C:\Updates\windows6.1-kb4474419-v3-x64.msu")
+
+$kbid="windows6.1-kb4474419-v3-x64"
+$update="September 2019 SHA2 Update"
+
+Write-Host "$(Get-Date -Format G): Extracting $update"
+Start-Process -FilePath "wusa.exe" -ArgumentList "C:\Updates\$kbid.msu /extract:C:\Updates" -Wait
+
+Write-Host "$(Get-Date -Format G): Installing $update"
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\$kbid.cab /quiet /norestart /LogPath:C:\Windows\Temp\$kbid.log" -Wait
+
+Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+Write-Host "$(Get-Date -Format G): Finished installing $update. The VM will now reboot and continue the installation process."

--- a/scripts/win-7-update-2019-10-update-rollup.ps1
+++ b/scripts/win-7-update-2019-10-update-rollup.ps1
@@ -1,0 +1,16 @@
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+Write-Host "$(Get-Date -Format G): Downloading October 2019 Update Rollup for Windows 7"
+(New-Object Net.WebClient).DownloadFile("http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/10/windows6.1-kb4519976-x64_58dae3b116e5c3f2e3d8e2623fd50d561601e145.msu", "C:\Updates\windows6.1-kb4519976-x64.msu")
+
+$kbid="windows6.1-kb4519976-x64"
+$update="October 2019 Update Rollup for Windows 7"
+
+Write-Host "$(Get-Date -Format G): Extracting $update"
+Start-Process -FilePath "wusa.exe" -ArgumentList "C:\Updates\$kbid.msu /extract:C:\Updates" -Wait
+
+Write-Host "$(Get-Date -Format G): Installing $update"
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\$kbid.cab /quiet /norestart /LogPath:C:\Windows\Temp\$kbid.log" -Wait
+
+Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+Write-Host "$(Get-Date -Format G): Finished installing $update. The VM will now reboot and continue the installation process."

--- a/scripts/win-7-update-net48.ps1
+++ b/scripts/win-7-update-net48.ps1
@@ -1,0 +1,10 @@
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+Write-Host "$(Get-Date -Format G): Downloading .NET Framework 4.8"
+(New-Object Net.WebClient).DownloadFile("https://download.visualstudio.microsoft.com/download/pr/014120d7-d689-4305-befd-3cb711108212/0fd66638cde16859462a6243a4629a50/ndp48-x86-x64-allos-enu.exe", "C:\Updates\ndp48-x86-x64-allos-enu.exe")
+ 
+Write-Host "$(Get-Date -Format G): Installing .NET Framework 4.8"
+Start-Process -FilePath "C:\Updates\ndp48-x86-x64-allos-enu.exe" -ArgumentList "/quiet /norestart" -Wait
+
+Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+Write-Host "$(Get-Date -Format G): Finished installing .NET Framework 4.8. The VM will now reboot and continue the installation process."

--- a/scripts/win-7-update-powershell-5.1.ps1
+++ b/scripts/win-7-update-powershell-5.1.ps1
@@ -1,0 +1,31 @@
+function Expand-ZIPFile($file, $destination)
+{
+    $shell = new-object -com shell.application
+    $zip = $shell.NameSpace($file)
+    foreach($item in $zip.items())
+    {
+        $shell.Namespace($destination).copyhere($item)
+    }
+}
+
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+Write-Host "$(Get-Date -Format G): Downloading Windows Management Framework 5.1"
+(New-Object Net.WebClient).DownloadFile("https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win7AndW2K8R2-KB3191566-x64.zip", "C:\Updates\Win7AndW2K8R2-KB3191566-x64.zip")
+
+Write-Host "$(Get-Date -Format G): Installing Windows Management Framework 5.1"
+Expand-ZipFile "C:\Updates\Win7AndW2K8R2-KB3191566-x64.zip" -destination "C:\Updates"
+
+Write-Host "$(Get-Date -Format G): Extracting $update"
+Start-Process -FilePath "wusa.exe" -ArgumentList "C:\Updates\Win7AndW2K8R2-KB3191566-x64.msu /extract:C:\Updates" -Wait
+
+Write-Host "$(Get-Date -Format G): Installing $update"
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\Windows6.1-KB2809215-x64.cab /quiet /norestart /LogPath:C:\Windows\Temp\KB2809215-x64.log" -Wait
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\Windows6.1-KB2872035-x64.cab /quiet /norestart /LogPath:C:\Windows\Temp\KB2872035-x64.log" -Wait
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\Windows6.1-KB2872047-x64.cab /quiet /norestart /LogPath:C:\Windows\Temp\KB2872047-x64.log" -Wait
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\Windows6.1-KB3033929-x64.cab /quiet /norestart /LogPath:C:\Windows\Temp\KB3033929-x64.log" -Wait
+Start-Process -FilePath "dism.exe" -ArgumentList "/online /add-package /PackagePath:C:\Updates\Windows6.1-KB3191566-x64.cab /quiet /norestart /LogPath:C:\Windows\Temp\KB3191566-x64.log" -Wait
+
+# Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+
+Write-Host "$(Get-Date -Format G): Finished installing Windows Management Framework 5.1. The VM will now reboot and continue the installation process."

--- a/scripts/win-7-update-sp1.ps1
+++ b/scripts/win-7-update-sp1.ps1
@@ -1,0 +1,17 @@
+New-Item -Path "C:\" -Name "Updates" -ItemType Directory
+
+# Service Pack 1 is an absolute requirement. Installing updates from Windows Update
+# will fail if SP1 is not installed.
+Write-Host "$(Get-Date -Format G): Downloading and installing Windows 7 Service Pack 1."
+Write-Host "$(Get-Date -Format G): This process can take up to 30 minutes."
+
+Write-Host "$(Get-Date -Format G): Downloading Windows 7 Service Pack 1"
+(New-Object Net.WebClient).DownloadFile("https://download.microsoft.com/download/0/A/F/0AFB5316-3062-494A-AB78-7FB0D4461357/windows6.1-KB976932-X64.exe", "C:\Updates\windows6.1-KB976932-X64.exe")
+
+Write-Host "$(Get-Date -Format G): Installing Windows 7 Service Pack 1"
+Start-Process -FilePath "C:\Updates\Windows6.1-KB976932-X64.exe" -ArgumentList "/unattend /nodialog /norestart" -Wait
+
+Remove-Item -LiteralPath "C:\Updates" -Force -Recurse
+
+Write-Host "$(Get-Date -Format G): Finished installing Windows 7 Service Pack 1. The VM will now reboot and continue the installation process."
+Write-Host "$(Get-Date -Format G): This may take a couple of minutes."

--- a/test.ps1
+++ b/test.ps1
@@ -14,7 +14,7 @@ $files = @(Get-ChildItem *.json)
 
 foreach ($file in $files) {
   Write-Host "`n`nValidate $file"
-  packer.exe validate $file
+  packer.exe validate -except=qemu $file
   if (-not $?)
   {
      throw "Packer validate found errors in $file!"

--- a/windows_7.json
+++ b/windows_7.json
@@ -7,13 +7,45 @@
       "winrm_timeout": "{{user `winrm_timeout`}}",
       "winrm_username": "vagrant",
       "cpus": 2,
+      "disk_size": 61440,
+      "floppy_files": [
+        "./answer_files/7/Autounattend.xml",
+        "./scripts/dis-updates.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/enable-winrm.ps1"
+      ],
+      "headless": true,
+      "iso_checksum": "1d0d239a252cb53e466d39e752b17c28",
+      "iso_checksum_type": "md5",
+      "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x64/EN/7600.16385.090713-1255_x64fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENXEVAL_EN_DVD.iso",
+      "memory": 4096,
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "8h",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "output_directory": "windows_7-qemu",
+      "qemuargs": [
+        [ "-drive", "file=windows_7-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1" ],
+        [ "-drive", "file={{ user `virtio_win_iso` }},media=cdrom,index=3" ],
+        [ "-cpu", "host,hv_relaxed,hv_vapic,hv_spinlocks=0x2fff,hv_vpindex,hv_runtime,hv_crash,hv_time,hv_synic,hv_stimer,hv_reset" ]
+      ]
+    },
+    {
+      "boot_wait": "2m",
+      "communicator": "winrm",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant",
+      "cpus": 2,
       "disk_adapter_type": "lsisas1068",
       "disk_size": 61440,
       "floppy_files": [
         "./answer_files/7/Autounattend.xml",
         "./scripts/dis-updates.ps1",
         "./scripts/microsoft-updates.bat",
-        "./scripts/win-updates.ps1"
+        "./scripts/enable-winrm.ps1"
       ],
       "guest_os_type": "windows7-64",
       "headless": false,
@@ -47,7 +79,7 @@
         "./answer_files/7/Autounattend.xml",
         "./scripts/dis-updates.ps1",
         "./scripts/microsoft-updates.bat",
-        "./scripts/win-updates.ps1"
+        "./scripts/enable-winrm.ps1"
       ],
       "guest_os_type": "Windows7_64",
       "headless": false,
@@ -104,12 +136,74 @@
   ],
   "provisioners": [
     {
-      "execute_command": "{{.Vars}} cmd /c C:/tmp/script.bat",
-      "remote_path": "/tmp/script.bat",
+      "script": "./scripts/win-7-update-sp1.ps1",
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
+      "script": "./scripts/win-7-update-2019-03-servicing-stack.ps1",
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
+      "script": "./scripts/win-7-update-2019-09-sha2.ps1",
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
+      "script": "./scripts/win-7-update-2019-09-servicing-stack.ps1",
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
+      "script": "./scripts/win-7-update-2016-convenience-rollup.ps1",
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
+      "script": "./scripts/win-7-update-2019-10-update-rollup.ps1",
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
+      "script": "./scripts/win-7-update-net48.ps1",
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
+      "script": "./scripts/win-7-update-powershell-5.1.ps1",
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
       "scripts": [
         "./scripts/vm-guest-tools.bat",
-        "./scripts/disable-auto-logon.bat",
         "./scripts/enable-rdp.bat",
+        "./scripts/enable-winrm.bat",
         "./scripts/compile-dotnet-assemblies.bat",
         "./scripts/compact.bat"
       ],
@@ -117,7 +211,8 @@
     }
   ],
   "variables": {
-    "winrm_timeout": "6h"
+    "winrm_timeout": "6h",
+    "virtio_win_iso": "~/virtio-win.iso"
   }
 }
 

--- a/windows_7.json
+++ b/windows_7.json
@@ -200,6 +200,30 @@
       "restart_timeout": "20m"
     },
     {
+      "type": "ansible",
+      "playbook_file": "./ansible/windows_update_security_updates.yml",
+      "extra_arguments": [
+        "--extra-vars", "ansible_shell_type=powershell ansible_shell_executable=None",
+        "--connection", "packer"
+      ]
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
+      "type": "ansible",
+      "playbook_file": "./ansible/windows_update.yml",
+      "extra_arguments": [
+        "--extra-vars", "ansible_shell_type=powershell ansible_shell_executable=None",
+        "--connection", "packer"
+      ]
+    },
+    {
+      "type": "windows-restart",
+      "restart_timeout": "20m"
+    },
+    {
       "scripts": [
         "./scripts/vm-guest-tools.bat",
         "./scripts/enable-rdp.bat",


### PR DESCRIPTION
The current approach for Windows 7 is to apply Windows Updates via `win-updates.ps1` which is triggered by `Autounattend.xml`.

The VM will start downloading and applying updates as they come in, with a maximum of 5 cycles and 500 updates per cycle.

For Windows 7, this approach seems to break down due to the large number of updates available. I left a build running for over 10 hours, and it still hadn't finished.

This PR takes a different approach for Windows 7, by manually installing a couple of well-known updates first, and then reverting to Windows Update. This allows me to build an up-to-date Windows 7 box in about 2 hours.

Long story short, this PR changes the update process so that these updates are installed manually:
1. [KB976932](https://support.microsoft.com/en-us/help/976932/): Windows 7 Service Pack 1,
2. [KB4490628](https://support.microsoft.com/en-us/help/4490628): Windows 7 Servicing Stack Update (March 2019),
3. [KB4474419](https://support.microsoft.com/en-us/help/4474419): Windows 7 SHA-2 Code Signing Support (September 2019) (requires 2),
4. [KB4516655](https://support.microsoft.com/en-us/help/4516655): Windows 7 Servicing Stack Update (September 2019) (requires 3),
5. [KB3125574](https://support.microsoft.com/en-us/help/3125574): Windows 7 Convenience Rollup (2016),
6. [KB4519976](https://support.microsoft.com/en-us/help/4519976): Windows 7 Monthly Rollup (October 2019),
7. .NET Framework 4.8
8. PowerShell 5.1 (requires 7)

These updates already get you a fairly well-patched Windows 7 system, though some security updates are not installed, and it still comes with IE 8.

As a final step, the remaining updates are installed using Ansible.

This PR takes a different approach towards installing updates. Instead of using the `Autounattend.xml` file, they are installed using Packer provisioners. The main reason for doing this was so that there's some console output available when the build is running, which you can use to get an idea of what Packer is doing. This is useful when building on remote build servers.

Because you can't install Windows Updates over a remote PowerShell session (which is what Packer uses to communicate with the VM), I've used Ansible to install them (which will create a scheduled task in Windows to get the updates running).

This departs a bit from the approach used by this repository, so let me know what you think. The main motivation is to get the build time for a Windows 7 box down to something reasonable (i.e. ~2 hours instead of 10+ hours :smile: )