### PR TITLE
Use TLS 1.2 for ultradefrag and VBoxGuestAdditions downloads

### DIFF
--- a/scripts/compact.bat
+++ b/scripts/compact.bat
@@ -8,7 +8,7 @@ if not exist "C:\Windows\Temp\7z1900-x64.msi" (
 msiexec /qb /i C:\Windows\Temp\7z1900-x64.msi
 
 if not exist "C:\Windows\Temp\ultradefrag.zip" (
-	powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://downloads.sourceforge.net/project/ultradefrag/stable-release/6.1.0/ultradefrag-portable-6.1.0.bin.amd64.zip', 'C:\Windows\Temp\ultradefrag.zip')" <NUL
+	powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://downloads.sourceforge.net/project/ultradefrag/stable-release/6.1.0/ultradefrag-portable-6.1.0.bin.amd64.zip', 'C:\Windows\Temp\ultradefrag.zip')" <NUL
 )
 
 if not exist "C:\Windows\Temp\ultradefrag-portable-6.1.0.amd64\udefrag.exe" (

--- a/scripts/vm-guest-tools.bat
+++ b/scripts/vm-guest-tools.bat
@@ -39,7 +39,7 @@ if exist "C:\Users\vagrant\VBoxGuestAdditions.iso" (
 )
 
 if not exist "C:\Windows\Temp\VBoxGuestAdditions.iso" (
-    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://download.virtualbox.org/virtualbox/6.0.10/VBoxGuestAdditions_6.0.10.iso', 'C:\Windows\Temp\VBoxGuestAdditions.iso')" <NUL
+    powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://download.virtualbox.org/virtualbox/6.0.10/VBoxGuestAdditions_6.0.10.iso', 'C:\Windows\Temp\VBoxGuestAdditions.iso')" <NUL
 )
 
 cmd /c ""C:\Program Files\7-Zip\7z.exe" x C:\Windows\Temp\VBoxGuestAdditions.iso -oC:\Windows\Temp\virtualbox"


### PR DESCRIPTION
Use TLS 1.2 for the ultradefrag and VBoxGuestAdditions downloads.

The requests to sourceforge.net and virtualbox.org fail without it, and it needs to be explicitly set in order for Windows Server 2012 R2 to use it.

Closes #219