### PR TITLE
Fixed packing with VirtualBox 6.x for Windows 7 and 8.1

### DIFF
--- a/windows_7.json
+++ b/windows_7.json
@@ -78,18 +78,6 @@
           "{{.Name}}",
           "--vrdeport",
           "13389"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--vcpenabled",
-          "off"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--vcpfile",
-          "windows_7.webm"
         ]
       ]
     }

--- a/windows_81.json
+++ b/windows_81.json
@@ -64,18 +64,6 @@
           "{{.Name}}",
           "--vrdeport",
           "13389"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--vcpenabled",
-          "off"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--vcpfile",
-          "windows_81.webm"
         ]
       ]
     }


### PR DESCRIPTION
Removed the (pointless) modifyvm statements --vcpenabled and --vcpfile (which are now --recording and --recordingfile). Since the default is "off" anyway, there is no good reason to set it to off again. See #223 