### PR TITLE
Fix typo in Server 2019 Core post processor

### DIFF
--- a/windows_2019_core.json
+++ b/windows_2019_core.json
@@ -94,7 +94,7 @@
       "keep_input_artifact": false,
       "output": "windows_2019_core_{{.Provider}}.box",
       "type": "vagrant",
-      "vagrantfile_template": "vagrantfile-windows_2016_core.template"
+      "vagrantfile_template": "vagrantfile-windows_2019_core.template"
     }
   ],
   "provisioners": [


### PR DESCRIPTION
Fixes a typo in Server 2019 Core post processor when it was copied from 2016.