### PR TITLE
Skip windows_7.json in test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/windows:ltsc2019 AS makeiso
+FROM mcr.microsoft.com/windows:1809 AS makeiso
 WORKDIR C:/source
 COPY . .
 RUN powershell -NoProfile -ExecutionPolicy unrestricted -file make_unattend_iso.ps1
 
-FROM mcr.microsoft.com/windowsservercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 ENV chocolateyUseWindowsCompression false
 
 RUN powershell -NoProfile -ExecutionPolicy unrestricted -Command \

--- a/test.ps1
+++ b/test.ps1
@@ -10,7 +10,7 @@ $env:PACKER_AZURE_RESOURCE_GROUP="dummy"
 $env:PACKER_AZURE_STORAGE_ACCOUNT="dummy"
 $env:AWS_S3_BUCKET="dummy"
 
-$files = @(Get-ChildItem *.json)
+$files = @(Get-ChildItem *.json | Where-Object -FilterScript { $_.Name -ne "windows_7.json" })
 
 foreach ($file in $files) {
   Write-Host "`n`nValidate $file"


### PR DESCRIPTION
After #217 has been merged, skip the `windows_7.json` in the PR tests. Installing Ansible on Windows (AppVeyor nodes for PR tests) is difficult.
