### PR TITLE
Use vbox 6.1.4 parameter --clipboard

### DIFF
--- a/vagrantfile-windows_10.template
+++ b/vagrantfile-windows_10.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 

--- a/vagrantfile-windows_2008_r2.template
+++ b/vagrantfile-windows_2008_r2.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 

--- a/vagrantfile-windows_2012.template
+++ b/vagrantfile-windows_2012.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 

--- a/vagrantfile-windows_2012_r2.template
+++ b/vagrantfile-windows_2012_r2.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 

--- a/vagrantfile-windows_2016.template
+++ b/vagrantfile-windows_2016.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 

--- a/vagrantfile-windows_2016_core.template
+++ b/vagrantfile-windows_2016_core.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 

--- a/vagrantfile-windows_2019_core.template
+++ b/vagrantfile-windows_2019_core.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 

--- a/vagrantfile-windows_7.template
+++ b/vagrantfile-windows_7.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 

--- a/vagrantfile-windows_81.template
+++ b/vagrantfile-windows_81.template
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
         v.customize ["modifyvm", :id, "--memory", 2048]
         v.customize ["modifyvm", :id, "--cpus", 2]
         v.customize ["modifyvm", :id, "--vram", 128]
-        v.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+        v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
         v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
     end
 


### PR DESCRIPTION
This reverts commit 0e6a9a3dcdd0d95bd749cce5dac3561bec86becf of PR #242 

VirtualBox 6.1 introduced incompatible parameter `--clipboard-mode`, but changed back to `--clipboard` with v6.1.4 again.
