### PR TITLE
Rename ssh_wait_timeout to ssh_timeout

### DIFF
--- a/windows_2008_r2.json
+++ b/windows_2008_r2.json
@@ -21,7 +21,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "6h",
+      "ssh_timeout": "6h",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
       "vmx_data": {
@@ -52,7 +52,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "6h",
+      "ssh_timeout": "6h",
       "type": "virtualbox-iso"
     }
   ],

--- a/windows_2008_r2_core.json
+++ b/windows_2008_r2_core.json
@@ -19,7 +19,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "2h",
+      "ssh_timeout": "2h",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
       "vmx_data": {
@@ -48,7 +48,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "2h",
+      "ssh_timeout": "2h",
       "type": "virtualbox-iso"
     }
   ],

--- a/windows_2012.json
+++ b/windows_2012.json
@@ -20,7 +20,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "2h",
+      "ssh_timeout": "2h",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
       "vmx_data": {
@@ -50,7 +50,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "2h",
+      "ssh_timeout": "2h",
       "type": "virtualbox-iso"
     }
   ],

--- a/windows_2012_r2_hyperv.json
+++ b/windows_2012_r2_hyperv.json
@@ -20,7 +20,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "6h",
+      "ssh_timeout": "6h",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
       "vmx_data": {
@@ -50,7 +50,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "6h",
+      "ssh_timeout": "6h",
       "type": "virtualbox-iso"
     }
   ],

--- a/windows_7.json
+++ b/windows_7.json
@@ -22,7 +22,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "8h",
+      "ssh_timeout": "8h",
       "type": "qemu",
       "accelerator": "kvm",
       "output_directory": "windows_7-qemu",
@@ -56,7 +56,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "8h",
+      "ssh_timeout": "8h",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
       "vmx_data": {
@@ -90,7 +90,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "8h",
+      "ssh_timeout": "8h",
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/windows_81.json
+++ b/windows_81.json
@@ -20,7 +20,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "4h",
+      "ssh_timeout": "4h",
       "tools_upload_flavor": "windows",
       "type": "vmware-iso",
       "vmx_data": {
@@ -50,7 +50,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_wait_timeout": "4h",
+      "ssh_timeout": "4h",
       "type": "virtualbox-iso",
       "vboxmanage": [
         [


### PR DESCRIPTION
Packer 1.5.4 shows an error

```
Validate C:\projects\packer-windows\windows_2008_r2.json
[warning] Fixable configuration found.
You may need to run `packer fix` to get your build to run
correctly. See debug log for more information.
Template validation failed. Errors are shown below.
Errors validating build 'vmware-iso'. 1 error occurred:
	* unknown configuration key: "ssh_wait_timeout"; raws is []interface {}{map[string]interface {}{"boot_wait":"2m", "cpus":2, "disk_adapter_type":"lsisas1068", "disk_size":131072, "floppy_files":[]interface {}{"./answer_files/2008_r2/Autounattend.xml", "./scripts/dis-updates.ps1", "./scripts/microsoft-updates.bat", "./scripts/win-updates.ps1", "./scripts/openssh.ps1"}, "guest_os_type":"windows7srv-64", "headless":true, "iso_checksum":"4263be2cf3c59177c45085c0a7bc6ca5", "iso_checksum_type":"md5", "iso_url":"https://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso", "memory":2048, "shutdown_command":"shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"", "ssh_password":"vagrant", "ssh_username":"vagrant", "ssh_wait_timeout":"6h", "tools_upload_flavor":"windows", "vmx_data":map[interface {}]interface {}{"RemoteDisplay.vnc.enabled":"false", "RemoteDisplay.vnc.port":"5900"}, "vmx_remove_ethernet_interfaces":true, "vnc_port_max":5980, "vnc_port_min":5900}, map[string]interface {}{"packer_build_name":"vmware-iso", "packer_builder_type":"vmware-iso", "packer_debug":false, "packer_force":false, "packer_on_error":"", "packer_template_path":"C:\\projects\\packer-windows\\windows_2008_r2.json", "packer_user_variables":map[interface {}]interface {}{}}} 
 and ctx data is map[interface {}]interface {}(nil)
Packer validate found errors in C:\projects\packer-windows\windows_2008_r2.json!
```
