### PR TITLE
Force the use of TLS1.2 when downloading Chocolatey

### DIFF
--- a/scripts/chocolatey.bat
+++ b/scripts/chocolatey.bat
@@ -1,1 +1,1 @@
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"


### PR DESCRIPTION
Support for TLS 1.0 and 1.1 was removed from chocolatey on February 3rd 2020 https://chocolatey.org/blog/remove-support-for-old-tls-versions.

Supersedes #243