### PR TITLE
Export vm_name as user variable for Windows 10

### DIFF
--- a/windows_10.json
+++ b/windows_10.json
@@ -29,7 +29,7 @@
         [ "-drive", "file=windows_10-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1" ],
         [ "-drive", "file={{ user `virtio_win_iso` }},media=cdrom,index=3" ]
       ],
-      "vm_name": "windows_10",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "{{user `winrm_timeout`}}",
       "winrm_username": "vagrant"
@@ -59,7 +59,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "switch_name": "{{user `switch_name`}}",
       "type": "hyperv-iso",
-      "vm_name": "windows_10",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "{{user `winrm_timeout`}}",
       "winrm_username": "vagrant"
@@ -92,7 +92,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
       "version": 14,
-      "vm_name": "windows_10",
+      "vm_name": "{{user `vm_name`}}",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
         "RemoteDisplay.vnc.port": "5900"
@@ -130,7 +130,7 @@
       "memory": 2048,
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "virtualbox-iso",
-      "vm_name": "windows_10",
+      "vm_name": "{{user `vm_name`}}",
       "winrm_password": "vagrant",
       "winrm_timeout": "{{user `winrm_timeout`}}",
       "winrm_username": "vagrant"
@@ -196,6 +196,7 @@
     "restart_timeout": "5m",
     "vhv_enable": "false",
     "winrm_timeout": "6h",
+    "vm_name": "windows_10",
     "virtio_win_iso": "~/virtio-win.iso"
   }
 }


### PR DESCRIPTION
Make use of a user variable `vm_name`, allowing to easily override with custom values during build
All configuration options keep the same value, when user variables are expanded.