### PR TITLE
Check before installing Windows 7 SP1

### DIFF
--- a/scripts/win-7-update-sp1.ps1
+++ b/scripts/win-7-update-sp1.ps1
@@ -1,3 +1,10 @@
+# First check if Service Pack 1 is installed.
+$os = Get-WmiObject -class Win32_OperatingSystem
+if ($os.ServicePackMajorVersion -ge 1) {
+    Write-Host "Windows 7 Service Pack 1 is already installed."
+    Exit
+}
+
 New-Item -Path "C:\" -Name "Updates" -ItemType Directory
 
 # Service Pack 1 is an absolute requirement. Installing updates from Windows Update


### PR DESCRIPTION
If you happen to use a Windows 7 SP1 iso, the build hangs forever when trying to update to Service Pack 1 in [scripts/win-7-update-sp1.ps1](https://github.com/StefanScherer/packer-windows/blob/494c62cf9945b5d688463ace0e8b748e75861d40/scripts/win-7-update-sp1.ps1).
It actually displays a dialog box with "Service Pack 1 is already installed", and waits for the user to press OK. But this dialog box is not visible to the user as it runs in the packer PowerShell, hence the build hanging forever.
Adding a little check whether SP1 is already installed or not resolves the issue.
Running the update with `/quiet` may also fix this but may also hide some useful information then introducing unexpected behavior (not tested).