### PR TITLE
Fix debugging output in Check-WindowsUpdates

### DIFF
--- a/scripts/win-updates.ps1
+++ b/scripts/win-updates.ps1
@@ -165,7 +165,7 @@ function Install-WindowsUpdates() {
 function Check-WindowsUpdates() {
     LogWrite "Checking For Windows Updates"
     $Username = $env:USERDOMAIN + "\" + $env:USERNAME
-    LogWrite "Script: " + $ScriptPath + "`nScript User: " + $Username + "`nStarted: " + (Get-Date).toString()
+    LogWrite "Script: $script:ScriptPath `nScript User: $Username `nStarted: $(Get-Date)"
 
     $script:UpdateSearcher = $script:UpdateSession.CreateUpdateSearcher()
     $script:successful = $FALSE


### PR DESCRIPTION
Minor patch to fix debugging output when checking for updates. Powershell seems not to like concatenation operator in string arguments.