### PR TITLE
Disabled Parallels Tools installation to fix for Issue 262

### DIFF
--- a/windows_2019_docker.json
+++ b/windows_2019_docker.json
@@ -122,6 +122,7 @@
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "parallels-iso",
       "parallels_tools_flavor": "win",
+      "parallels_tools_mode": "disable",
       "prlctl": [
         ["set", "{{.Name}}", "--adaptive-hypervisor", "on"],
         ["set", "{{.Name}}", "--efi-boot", "off"]


### PR DESCRIPTION
Fix for #262 

Disabled the installation of Parallels Tools, similarly to the Hyper-V and VirtualBox builders. For a headless Windows Server Core installation this shouldn't be an issue. 
Overview of Parallels Tools features: https://download.parallels.com/desktop/v12/docs/en_US/Parallels%20Desktop%20User%27s%20Guide/32789.htm