### PR TITLE
Add KVM support for Windows 2019 Core

### DIFF
--- a/windows_2019_core.json
+++ b/windows_2019_core.json
@@ -1,6 +1,42 @@
 {
   "builders": [
     {
+      "accelerator": "kvm",
+      "boot_wait": "0s",
+      "communicator": "winrm",
+      "cpus": 2,
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/enable-winrm.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "headless": true,
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": "{{user `memory`}}",
+      "output_directory": "windows_2019_docker-qemu",
+      "qemuargs": [
+        [
+          "-drive",
+          "file=windows_2019-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-drive",
+          "file={{ user `virtio_win_iso` }},media=cdrom,index=3"
+        ]
+      ],
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "type": "qemu",
+      "vm_name": "WindowsServer2019Docker",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    },
+    {
       "boot_wait": "0s",
       "communicator": "winrm",
       "configuration_version": "8.0",
@@ -128,7 +164,8 @@
     "iso_checksum": "sha256:549bca46c055157291be6c22a3aaaed8330e78ef4382c99ee82c896426a1cee1",
     "iso_url": "https://software-download.microsoft.com/download/pr/17763.737.190906-2324.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us_1.iso",
     "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019",
-    "winrm_timeout": "6h"
+    "winrm_timeout": "6h",
+    "virtio_win_iso": "~/virtio-win.iso"
   }
 }
 


### PR DESCRIPTION
Together with #270 (for CI) and #272 (for WinRM integration), this allows me to reliably build Windows 2019 images for KVM and VirtualBox using Azure Pipelines & Travis.