### PR TITLE
Fixed broken Windows 7 SP1 download link.

### DIFF
--- a/scripts/win-7-update-sp1.ps1
+++ b/scripts/win-7-update-sp1.ps1
@@ -13,7 +13,7 @@ Write-Host "$(Get-Date -Format G): Downloading and installing Windows 7 Service 
 Write-Host "$(Get-Date -Format G): This process can take up to 30 minutes."
 
 Write-Host "$(Get-Date -Format G): Downloading Windows 7 Service Pack 1"
-(New-Object Net.WebClient).DownloadFile("https://download.microsoft.com/download/0/A/F/0AFB5316-3062-494A-AB78-7FB0D4461357/windows6.1-KB976932-X64.exe", "C:\Updates\windows6.1-KB976932-X64.exe")
+(New-Object Net.WebClient).DownloadFile("http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe", "C:\Updates\windows6.1-KB976932-X64.exe")
 
 Write-Host "$(Get-Date -Format G): Installing Windows 7 Service Pack 1"
 $process = (Start-Process -FilePath "C:\Updates\Windows6.1-KB976932-X64.exe" -ArgumentList "/unattend /nodialog /norestart" -PassThru)


### PR DESCRIPTION
Old Win7 SP7 download link returning a HTTP 404. Updated to new download location on Microsoft's "windowsupdate.com" site.