### PR TITLE
Refactor vmx_version into a user variable

### DIFF
--- a/windows_10.json
+++ b/windows_10.json
@@ -94,7 +94,7 @@
       "memory": "{{user `memory`}}",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "type": "vmware-iso",
-      "version": 14,
+      "version": "{{user `vmx_version`}}",
       "vm_name": "{{user `vm_name`}}",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
@@ -243,6 +243,7 @@
     "vhv_enable": "false",
     "virtio_win_iso": "~/virtio-win.iso",
     "vm_name": "windows_10",
-    "winrm_timeout": "6h"
+    "winrm_timeout": "6h",
+    "vmx_version": "14"
   }
 }

--- a/windows_2019.json
+++ b/windows_2019.json
@@ -92,7 +92,7 @@
       "memory": "{{user `memory`}}",
       "shutdown_command": "a:/sysprep.bat",
       "type": "vmware-iso",
-      "version": 14,
+      "version": "{{user `vmx_version`}}",
       "vm_name": "WindowsServer2019",
       "vmx_data": {
         "RemoteDisplay.vnc.enabled": "false",
@@ -186,7 +186,8 @@
     "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019",
     "restart_timeout": "5m",
     "virtio_win_iso": "~/virtio-win.iso",
-    "winrm_timeout": "2h"
+    "winrm_timeout": "2h",
+    "vmx_version": "14"
   }
 }
 


### PR DESCRIPTION
Refactor the vmx_version to a user variable so it's possible to support older version of VMware Fusion and VMware Workstation.