### PR TITLE
Update Windows 10 version to 2004 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following Windows versions are known to work (built with VMware Fusion Pro
 11.0.2):
 
 * Windows 10
-  * Windows 10 1809 -> Vagrant Cloud box [StefanScherer/windows_10](https://app.vagrantup.com/StefanScherer/boxes/windows_10)
+  * Windows 10 2004 -> Vagrant Cloud box [StefanScherer/windows_10](https://app.vagrantup.com/StefanScherer/boxes/windows_10)
   * Windows 10 Insider
 * Windows Server 2016 Desktop -> Vagrant Cloud box [StefanScherer/windows_2016](https://app.vagrantup.com/StefanScherer/boxes/windows_2016)
 * Windows Server 2019 Desktop -> Vagrant Cloud box [StefanScherer/windows_2019](https://app.vagrantup.com/StefanScherer/boxes/windows_2019)


### PR DESCRIPTION
Today, the documentation in the README states that the Windows 10 version is 1809 but it is now 2004 according to commit e6523ef182b53aee86a8459d2b0b0f66c571f572