### PR TITLE
Force the use of TLS1.2 when downloading 7zip

### DIFF
--- a/scripts/vm-guest-tools.bat
+++ b/scripts/vm-guest-tools.bat
@@ -1,8 +1,8 @@
 if not exist "C:\Windows\Temp\7z1900-x64.msi" (
-    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')" <NUL
+    powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')" <NUL
 )
 if not exist "C:\Windows\Temp\7z1900-x64.msi" (
-    powershell -Command "Start-Sleep 5 ; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')" <NUL
+    powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Start-Sleep 5 ; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1900-x64.msi', 'C:\Windows\Temp\7z1900-x64.msi')" <NUL
 )
 msiexec /qb /i C:\Windows\Temp\7z1900-x64.msi
 


### PR DESCRIPTION
The 7zip download appears to require TLS1.2 now. The [powershell
script][1] has this configuration, also add it to the batch script.

[1]: https://github.com/StefanScherer/packer-windows/blob/9ab9ff56d7f003b284a8538e230eb12ad8799ec3/scripts/vm-guest-tools.ps1#L2