### PR TITLE
Reach winrm on public ip from anywhere

### DIFF
--- a/scripts/enable-winrm.ps1
+++ b/scripts/enable-winrm.ps1
@@ -12,6 +12,6 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 winrm set winrm/config/client/auth '@{Basic="true"}'
 winrm set winrm/config/listener?Address=*+Transport=HTTP '@{Port="5985"}'
 netsh advfirewall firewall set rule group="Windows Remote Administration" new enable=yes
-netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=allow
+netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=allow remoteip=any
 Set-Service winrm -startuptype "auto"
 Restart-Service winrm


### PR DESCRIPTION
I had trouble with this windows 10 box on a local Windows 10 Hyper-V.
I was running this box on the „Default Network“ for its DHCP and trying to reach it from a WSL2 machine on the WSL virtual switch, which doesn't offer DHCP
This way the Windows firewall was blocking me from access to WinRM 

This patch opens WinRM on a Public IP to connections from anywhere