### PR TITLE
Add resources for building Windows Server 2022 with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following Windows versions are known to work (built with VMware Fusion Pro
 * Windows Server 2022 Desktop -> Vagrant Cloud box [StefanScherer/windows_2022](https://app.vagrantup.com/StefanScherer/boxes/windows_2022)
 * Windows Server 2019 Desktop -> Vagrant Cloud box [StefanScherer/windows_2019](https://app.vagrantup.com/StefanScherer/boxes/windows_2019)
 * Windows Server Core
+  * Windows Server 2022 without and with Docker -> Vagrant Cloud box [StefanScherer/windows_2022_docker](https://app.vagrantup.com/StefanScherer/boxes/windows_2022_docker)
   * Windows Server 2019 without and with Docker -> Vagrant Cloud box [StefanScherer/windows_2019_docker](https://app.vagrantup.com/StefanScherer/boxes/windows_2019_docker)
   * Windows Server 1709, 1803, 1809, 1903, 1909, and 2004 all without and with Docker
   * Windows Server InsiderPreview Semi-Annual without and with Docker
@@ -236,6 +237,20 @@ packer build --only=parallels-iso windows_2019_docker.json
 The Parallels builder config turns `efi boot` off in order to use the same answer file like all the other builders. If you find you need to turn `efi boot` on then make sure to adjust the appropriate answer file, especially the section regarding the partitioning of the disk.
 If you need to further customize the VM, consult the documentation at https://www.packer.io/docs/builders/parallels-iso.html. 
 
+
+### VirtualBox support
+
+When using VirtualBox, you can use the following sample command to build a
+corresponding VM image:
+
+```
+packer build --only=virtualbox-iso windows_2022_docker.json
+```
+
+After building, you can expect a box package like `windows_2022_docker_virtualbox.box`
+in the working directory.
+
+
 ### Using .box Files With Vagrant
 
 The generated box files include a Vagrantfile template that is suitable for use
@@ -251,4 +266,4 @@ vagrant up --provider hyperv
 
 ### Contributing
 
-Pull request are welcome!
+Pull requests are welcome!

--- a/build_windows_2022_docker.ps1
+++ b/build_windows_2022_docker.ps1
@@ -1,0 +1,8 @@
+if (Test-Path ./output-hyperv-iso) {
+  Remove-Item -Recurse -Force ./output-hyperv-iso
+}
+
+packer build --only=hyperv-iso `
+  --var iso_url=./iso/20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso `
+  --var iso_checksum="sha256:4f1457c4fe14ce48c9b2324924f33ca4f0470475e6da851b39ccbf98f44e7852" `
+  windows_2022_docker.json

--- a/build_windows_2022_docker.sh
+++ b/build_windows_2022_docker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Insider ISO
+packer build \
+  --only=vmware-iso \
+  --var vhv_enable=true \
+  --var autounattend=./tmp/2022_core/Autounattend.xml \
+  --var iso_url=~/.cache/packer/caff720c675a0670657cb6bcfb438d3b0c664081.iso \
+  --var iso_checksum="sha256:4f1457c4fe14ce48c9b2324924f33ca4f0470475e6da851b39ccbf98f44e7852" \
+  windows_2022_docker.json

--- a/scripts/docker/install-docker.ps1
+++ b/scripts/docker/install-docker.ps1
@@ -1,6 +1,6 @@
 ﻿# use docker_provider:  "ee", "ce", "master" or ""
 $docker_provider = "ce"
-$docker_version = "20.10.7"
+$docker_version = "20.10.17"
 if (Test-Path env:docker_provider) {
   $docker_provider = $env:docker_provider
 }

--- a/windows_2019_docker.json
+++ b/windows_2019_docker.json
@@ -237,7 +237,7 @@
     "memory": "2048",
     "docker_images": "mcr.microsoft.com/windows/nanoserver:1809 mcr.microsoft.com/windows/servercore:ltsc2019 mcr.microsoft.com/windows/servercore:1809 mcr.microsoft.com/windows:1809",
     "docker_provider": "ce",
-    "docker_version": "20.10.7",
+    "docker_version": "20.10.17",
     "headless": "false",
     "iso_checksum": "sha256:549bca46c055157291be6c22a3aaaed8330e78ef4382c99ee82c896426a1cee1",
     "iso_url": "https://software-download.microsoft.com/download/pr/17763.737.190906-2324.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us_1.iso",

--- a/windows_2022_docker.json
+++ b/windows_2022_docker.json
@@ -237,7 +237,7 @@
     "memory": "2048",
     "docker_images": "mcr.microsoft.com/windows/nanoserver:ltsc2022 mcr.microsoft.com/windows/servercore:ltsc2022",
     "docker_provider": "ce",
-    "docker_version": "20.10.7",
+    "docker_version": "20.10.17",
     "headless": "false",
     "iso_checksum": "sha256:4f1457c4fe14ce48c9b2324924f33ca4f0470475e6da851b39ccbf98f44e7852",
     "iso_url": "https://software-download.microsoft.com/download/sg/20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",

--- a/windows_2022_docker.json
+++ b/windows_2022_docker.json
@@ -1,0 +1,250 @@
+{
+  "builders": [
+    {
+      "accelerator": "kvm",
+      "boot_wait": "0s",
+      "communicator": "winrm",
+      "cpus": 2,
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/docker/enable-winrm.ps1",
+        "./scripts/docker/2016/install-containers-feature.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "headless": true,
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": "{{user `memory`}}",
+      "output_directory": "windows_2022_docker-qemu",
+      "qemuargs": [
+        [
+          "-drive",
+          "file=windows_2022_docker-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-drive",
+          "file={{ user `virtio_win_iso` }},media=cdrom,index=3"
+        ]
+      ],
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "type": "qemu",
+      "vm_name": "WindowsServer2022Docker",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    },
+    {
+      "boot_wait": "0s",
+      "communicator": "winrm",
+      "configuration_version": "8.0",
+      "cpus": 2,
+      "disk_size": "{{user `disk_size`}}",
+      "enable_secure_boot": true,
+      "enable_virtualization_extensions": true,
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/docker/enable-winrm.ps1",
+        "./scripts/docker/2016/install-containers-feature.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "guest_additions_mode": "disable",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": "{{user `memory`}}",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "switch_name": "{{user `hyperv_switchname`}}",
+      "type": "hyperv-iso",
+      "vm_name": "WindowsServer2022Docker",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    },
+    {
+      "boot_wait": "2m",
+      "communicator": "winrm",
+      "cpus": 2,
+      "disk_adapter_type": "lsisas1068",
+      "disk_size": "{{user `disk_size`}}",
+      "disk_type_id": "{{user `disk_type_id`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/docker/enable-winrm.ps1",
+        "./scripts/docker/2016/install-containers-feature.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "guest_os_type": "windows9srv-64",
+      "headless": "{{user `headless`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": "{{user `memory`}}",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "type": "vmware-iso",
+      "version": 14,
+      "vm_name": "WindowsServer2022Docker",
+      "vmx_data": {
+        "RemoteDisplay.vnc.enabled": "false",
+        "RemoteDisplay.vnc.port": "5900",
+        "vhv.enable": "{{user `vhv_enable`}}"
+      },
+      "vmx_remove_ethernet_interfaces": true,
+      "vnc_port_max": 5980,
+      "vnc_port_min": 5900,
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    },
+    {
+      "boot_wait": "2m",
+      "communicator": "winrm",
+      "cpus": 2,
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/docker/enable-winrm.ps1",
+        "./scripts/docker/2016/install-containers-feature.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "guest_os_type": "win-2022",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": "{{user `memory`}}",
+      "parallels_tools_flavor": "win",
+      "parallels_tools_mode": "disable",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--adaptive-hypervisor",
+          "on"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--efi-boot",
+          "off"
+        ]
+      ],
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "type": "parallels-iso",
+      "vm_name": "WindowsServer2022Docker",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    },
+    {
+      "boot_wait": "2m",
+      "communicator": "winrm",
+      "cpus": 2,
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `autounattend`}}",
+        "./scripts/disable-screensaver.ps1",
+        "./scripts/disable-winrm.ps1",
+        "./scripts/docker/enable-winrm.ps1",
+        "./scripts/docker/2016/install-containers-feature.ps1",
+        "./scripts/microsoft-updates.bat",
+        "./scripts/win-updates.ps1"
+      ],
+      "guest_additions_mode": "disable",
+      "guest_os_type": "Windows2016_64",
+      "headless": "{{user `headless`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "memory": "{{user `memory`}}",
+      "post_shutdown_delay": "10s",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "type": "virtualbox-iso",
+      "vm_name": "WindowsServer2022Docker",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "winrm_username": "vagrant"
+    }
+  ],
+  "post-processors": [
+    {
+      "keep_input_artifact": false,
+      "output": "windows_2022_docker_{{.Provider}}.box",
+      "type": "vagrant",
+      "vagrantfile_template": "vagrantfile-windows_2016.template"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "{{ .Vars }} cmd /c \"{{ .Path }}\"",
+      "scripts": [
+        "./scripts/enable-rdp.bat"
+      ],
+      "type": "windows-shell"
+    },
+    {
+      "scripts": [
+        "./scripts/vm-guest-tools.ps1",
+        "./scripts/debloat-windows.ps1",
+        "./scripts/docker/set-winrm-automatic.ps1"
+      ],
+      "type": "powershell"
+    },
+    {
+      "restart_timeout": "{{user `restart_timeout`}}",
+      "type": "windows-restart"
+    },
+    {
+      "environment_vars": [
+        "docker_images={{user `docker_images`}}",
+        "docker_provider={{user `docker_provider`}}",
+        "docker_version={{user `docker_version`}}"
+      ],
+      "scripts": [
+        "./scripts/docker/add-docker-group.ps1",
+        "./scripts/docker/install-docker.ps1",
+        "./scripts/docker/docker-pull.ps1",
+        "./scripts/wait-for-tiworker.ps1",
+        "./scripts/docker/open-docker-insecure-port.ps1",
+        "./scripts/docker/open-docker-swarm-ports.ps1",
+        "./scripts/docker/remove-docker-key-json.ps1",
+        "./scripts/docker/disable-windows-defender.ps1"
+      ],
+      "type": "powershell"
+    },
+    {
+      "scripts": [
+        "./scripts/set-winrm-automatic.bat",
+        "./scripts/uac-enable.bat",
+        "./scripts/compile-dotnet-assemblies.bat",
+        "./scripts/dis-updates.bat",
+        "./scripts/compact.bat"
+      ],
+      "type": "windows-shell"
+    }
+  ],
+  "variables": {
+    "autounattend": "./answer_files/2022_core/Autounattend.xml",
+    "disk_size": "81920",
+    "disk_type_id": "1",
+    "memory": "2048",
+    "docker_images": "mcr.microsoft.com/windows/nanoserver:ltsc2022 mcr.microsoft.com/windows/servercore:ltsc2022",
+    "docker_provider": "ce",
+    "docker_version": "20.10.7",
+    "headless": "false",
+    "iso_checksum": "sha256:4f1457c4fe14ce48c9b2324924f33ca4f0470475e6da851b39ccbf98f44e7852",
+    "iso_url": "https://software-download.microsoft.com/download/sg/20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+    "manually_download_iso_from": "https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2022",
+    "restart_timeout": "5m",
+    "vhv_enable": "false",
+    "winrm_timeout": "6h"
+  }
+}
+


### PR DESCRIPTION
Dear Stefan and all contributors,

thank you very much for maintaing this excellent repository. We are aiming to modernize the sweetness of what is already available for the Windows Server 2016 and 2019 releases and add corresponding support for Windows Server 2022.

While you added general support for Windows 2022 with #301 already, corresponding resources for the Docker-flavoured builds for `windows_2022_docker` have still been missing. Using `windows_2019_docker` as a blueprint and by mixing in the updates from `windows_2022`, this patch was easy to make. We hope you like it.

However, you would need to build and publish the corresponding artefacts to Vagrant Cloud after integrating the patch. Therefore, we are humbly asking for your support.

Keep up the spirit and with kind regards,
Andreas.
