### PR TITLE
Adjusted variables in shell script

### DIFF
--- a/build_windows_10.sh
+++ b/build_windows_10.sh
@@ -4,9 +4,9 @@
 #  --var iso_url=~/Downloads/19041.264.200511-0456.vb_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso \
 #  windows_10.json
 packer build --only=vmware-iso \
-  --var iso_url=~/packer_cache/msdn/de_windows_10_consumer_editions_version_2004_x64_dvd_7efdffc7.iso \
-  --var iso_checksum=sha256:908bca712c7f5ec5655882237aa447dde446e9a5e5178e2202ebae0157fd0d29 \
-  --var autounattend=tmp/10_pro_de/Autounattend.xml \
   windows_10.json
+#  --var iso_url=~/packer_cache/msdn/de_windows_10_consumer_editions_version_2004_x64_dvd_7efdffc7.iso \
+#  --var iso_checksum=sha256:908bca712c7f5ec5655882237aa447dde446e9a5e5178e2202ebae0157fd0d29 \
+#  --var autounattend=tmp/10_pro_de/Autounattend.xml \
 #  windows_10_insider.json
 


### PR DESCRIPTION
I detected that the iso_url is overwritten in the build shell script. This leads to the fact that the latest Windows 10 version 21H2 which is referenced as default in the `.json` file is not used when building this way. Maybe this is also the reason why the tag https://app.vagrantup.com/StefanScherer/boxes/windows_10/versions/2021.12.09 doesn't contain 21H2 but an older version even though the 21H2 change was contained in the json file of the tag.

I also removed the autounattend var as this was not available here.