### PR TITLE
Update enable-winrm.ps1

### DIFF
--- a/scripts/enable-winrm.ps1
+++ b/scripts/enable-winrm.ps1
@@ -1,6 +1,4 @@
-$NetworkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}"))
-$Connections = $NetworkListManager.GetNetworkConnections()
-$Connections | ForEach-Object { $_.GetNetwork().SetCategory(1) }
+Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private
 
 Enable-PSRemoting -Force
 winrm quickconfig -q


### PR DESCRIPTION
Close #322 
Make enable-winrm.ps1 compatible with latest windows update changes.
@StefanScherer I successfully build a windows server 2022 hyperv vm with this change.