### PR TITLE
Resolution for Issue #331: Successful Fix Implementation

### DIFF
--- a/answer_files/11/Autounattend.xml
+++ b/answer_files/11/Autounattend.xml
@@ -57,6 +57,26 @@
         </component>
         
         <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+
+            <!-- Run SynchronousCommand at the installation of windows -->
+            <RunSynchronous>
+
+                <!-- Bypass TPM Check -->
+                <RunSynchronousCommand wcm:action="add">
+                    <Description>Bypass TPM Check</Description>
+                    <Order>1</Order>
+                    <Path>reg add HKLM\SYSTEM\Setup\LabConfig /t REG_DWORD /v BypassTPMCheck /d 1 /f</Path>
+                </RunSynchronousCommand>
+                
+                <!-- Bypass Secure Boot Check -->
+                <RunSynchronousCommand wcm:action="add">
+                    <Description>Bypass Secure Boot Check</Description>
+                    <Order>2</Order>
+                    <Path>reg add HKLM\SYSTEM\Setup\LabConfig /t REG_DWORD /v BypassSecureBootCheck /d 1 /f</Path>
+                </RunSynchronousCommand>
+
+            </RunSynchronous>
+
             <DiskConfiguration>
                 <Disk wcm:action="add">
                     <CreatePartitions>

--- a/windows_11.json
+++ b/windows_11.json
@@ -1,13 +1,7 @@
 {
   "builders": [
     {
-      "boot_command": [
-        "<leftShiftOn><f10><leftShiftOff><wait>",
-        "reg add HKLM\\SYSTEM\\Setup\\LabConfig /t REG_DWORD /v BypassTPMCheck /d 1<return>",
-        "reg add HKLM\\SYSTEM\\Setup\\LabConfig /t REG_DWORD /v BypassSecureBootCheck /d 1<return><wait>",
-        "exit<return>",
-        "<wait><return>"
-      ],
+      "boot_command": "",
       "boot_wait": "2m",
       "communicator": "winrm",
       "configuration_version": "8.0",
@@ -35,13 +29,7 @@
       "winrm_username": "vagrant"
     },
     {
-      "boot_command": [
-        "<leftShiftOn><f10><leftShiftOff><wait>",
-        "reg add HKLM\\SYSTEM\\Setup\\LabConfig /t REG_DWORD /v BypassTPMCheck /d 1<return>",
-        "reg add HKLM\\SYSTEM\\Setup\\LabConfig /t REG_DWORD /v BypassSecureBootCheck /d 1<return><wait>",
-        "exit<return>",
-        "<wait><return>"
-      ],
+      "boot_command": "",
       "boot_wait": "2m",
       "communicator": "winrm",
       "cpus": 2,
@@ -78,13 +66,7 @@
       "winrm_username": "vagrant"
     },
     {
-      "boot_command": [
-        "<leftShiftOn><f10><leftShiftOff><wait>",
-        "reg add HKLM\\SYSTEM\\Setup\\LabConfig /t REG_DWORD /v BypassTPMCheck /d 1<return>",
-        "reg add HKLM\\SYSTEM\\Setup\\LabConfig /t REG_DWORD /v BypassSecureBootCheck /d 1<return><wait>",
-        "exit<return>",
-        "<wait><return>"
-      ],
+      "boot_command": "",
       "boot_wait": "2m",
       "communicator": "winrm",
       "cpus": 2,
@@ -112,13 +94,7 @@
       "winrm_username": "vagrant"
     },
     {
-      "boot_command": [
-        "<leftShiftOn><f10><leftShiftOff><wait>",
-        "reg add HKLM\\SYSTEM\\Setup\\LabConfig /t REG_DWORD /v BypassTPMCheck /d 1<return>",
-        "reg add HKLM\\SYSTEM\\Setup\\LabConfig /t REG_DWORD /v BypassSecureBootCheck /d 1<return><wait>",
-        "exit<return>",
-        "<wait><return>"
-      ],
+      "boot_command": "",
       "boot_wait": "2m",
       "communicator": "winrm",
       "cpus": 2,


### PR DESCRIPTION
# This is my fix of the #331 issue. 

To address the issue encountered during the installation of Windows 11, a solution has been identified and successfully applied. The problem surfaced when attempting to boot into Windows 11 and proceed with the installation phase. A specific message was encountered that hindered the process:

``` markdown
# This PC can't run Windows 11

This PC doesn't meet the minimum system requirements to install this version of Windows. For more information, visit https://aka.ms/WindowsSysReq
``` 

To overcome this obstacle, a modification was made to the installation configuration. The `boot_commands` sections of the file `windows_11.json`, which is crucial for guiding the installation process, was relocated. Initially situated outside the scope of the primary installation instructions, it was moved directly into the `Autounattend.xml` file located within the `answer_files/11` directory. This adjustment is clearly delineated in the provided diff documentation.

This change effectively resolved the issue, allowing for a smooth and error-free installation of Windows 11. By integrating the `boot_commands` directly into the `Autounattend.xml` file, the installation process is now streamlined, bypassing the previously encountered message and facilitating a successful installation.