### PR TITLE
Update VMware Tools links after Broadcom acquisition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "submodules/Debloat-Windows-10"]
+	path = submodules/Debloat-Windows-10
+	url = https://github.com/JunielKatarn/Debloat-Windows-10.git
+	branch = win11-2025

--- a/scripts/debloat-windows.ps1
+++ b/scripts/debloat-windows.ps1
@@ -16,14 +16,13 @@ else {
   #. $env:TEMP\Debloat-Windows-10-master\scripts\disable-services.ps1
   Write-Output 'Disable Windows Defender'
   if ($(Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ProductName.StartsWith("Windows 10")) {
-    #. $env:TEMP\Debloat-Windows-10-master\scripts\disable-windows-defender.ps1
-    . "$(Split-Path $PSScriptRoot)\submodules\Debloat-Windows-10\scripts\disable-windows-defender.ps1"
+    . "A:\disable-windows-defender.ps1"
   }
   else {
     Uninstall-WindowsFeature Windows-Defender
   }
   Write-Output 'Optimize Windows Update'
-  . "$(Split-Path $PSScriptRoot)\submodules\Debloat-Windows-10\scripts\optimize-windows-update.ps1"
+  . "A:\optimize-windows-update.ps1"
   #Write-Output Disable Windows Update
   #Set-Service wuauserv -StartupType Disabled
   #Write-Output Remove OneDrive

--- a/scripts/debloat-windows.ps1
+++ b/scripts/debloat-windows.ps1
@@ -1,8 +1,8 @@
 ﻿if ($env:PACKER_BUILDER_TYPE -And $($env:PACKER_BUILDER_TYPE).startsWith("hyperv")) {
-  Write-Output Skip debloat steps in Hyper-V build.
+  Write-Output 'Skip debloat steps in Hyper-V build'
 }
 else {
-  Write-Output Downloading debloat zip
+  Write-Output 'Downloading debloat zip'
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   $url = "https://github.com/StefanScherer/Debloat-Windows-10/archive/master.zip"
   (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\debloat.zip")
@@ -14,14 +14,14 @@ else {
   #. $env:TEMP\Debloat-Windows-10-master\scripts\block-telemetry.ps1
   #Write-Output Disable services
   #. $env:TEMP\Debloat-Windows-10-master\scripts\disable-services.ps1
-  Write-Output Disable Windows Defender
+  Write-Output 'Disable Windows Defender'
   if ($(Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ProductName.StartsWith("Windows 10")) {
     . $env:TEMP\Debloat-Windows-10-master\scripts\disable-windows-defender.ps1
   }
   else {
     Uninstall-WindowsFeature Windows-Defender
   }
-  Write-Output Optimize Windows Update
+  Write-Output 'Optimize Windows Update'
   . $env:TEMP\Debloat-Windows-10-master\scripts\optimize-windows-update.ps1
   #Write-Output Disable Windows Update
   #Set-Service wuauserv -StartupType Disabled

--- a/scripts/debloat-windows.ps1
+++ b/scripts/debloat-windows.ps1
@@ -2,11 +2,11 @@
   Write-Output 'Skip debloat steps in Hyper-V build'
 }
 else {
-  Write-Output 'Downloading debloat zip'
-  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-  $url = "https://github.com/StefanScherer/Debloat-Windows-10/archive/master.zip"
-  (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\debloat.zip")
-  Expand-Archive -Path $env:TEMP\debloat.zip -DestinationPath $env:TEMP -Force
+  # Write-Output 'Downloading debloat zip'
+  # [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  # $url = "https://github.com/StefanScherer/Debloat-Windows-10/archive/master.zip"
+  # (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\debloat.zip")
+  # Expand-Archive -Path $env:TEMP\debloat.zip -DestinationPath $env:TEMP -Force
 
   #Write-Output Disable scheduled tasks
   #. $env:TEMP\Debloat-Windows-10-master\utils\disable-scheduled-tasks.ps1
@@ -16,18 +16,19 @@ else {
   #. $env:TEMP\Debloat-Windows-10-master\scripts\disable-services.ps1
   Write-Output 'Disable Windows Defender'
   if ($(Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ProductName.StartsWith("Windows 10")) {
-    . $env:TEMP\Debloat-Windows-10-master\scripts\disable-windows-defender.ps1
+    #. $env:TEMP\Debloat-Windows-10-master\scripts\disable-windows-defender.ps1
+    . "$(Split-Path $PSScriptRoot)\submodules\Debloat-Windows-10\scripts\disable-windows-defender.ps1"
   }
   else {
     Uninstall-WindowsFeature Windows-Defender
   }
   Write-Output 'Optimize Windows Update'
-  . $env:TEMP\Debloat-Windows-10-master\scripts\optimize-windows-update.ps1
+  . "$(Split-Path $PSScriptRoot)\submodules\Debloat-Windows-10\scripts\optimize-windows-update.ps1"
   #Write-Output Disable Windows Update
   #Set-Service wuauserv -StartupType Disabled
   #Write-Output Remove OneDrive
   #. $env:TEMP\Debloat-Windows-10-master\scripts\remove-onedrive.ps1
 
-  Remove-Item $env:TEMP\debloat.zip
-  Remove-Item -recurse $env:TEMP\Debloat-Windows-10-master
+  # Remove-Item $env:TEMP\debloat.zip
+  # Remove-Item -recurse $env:TEMP\Debloat-Windows-10-master
 }

--- a/scripts/docker/docker-pull.ps1
+++ b/scripts/docker/docker-pull.ps1
@@ -10,7 +10,7 @@ function DockerPull {
     return
   }
 
-  Write-Output Installing $image ...
+  Write-Output "Installing $image ..."
   $j = Start-Job -ScriptBlock { docker pull $args[0] } -ArgumentList "$image"
   while ( $j.JobStateInfo.state -ne "Completed" -And $j.JobStateInfo.state -ne "Failed" ) {
     Write-Output $j.JobStateInfo.state
@@ -28,7 +28,7 @@ function DockerRun {
     return
   }
 
-  Write-Output Run first container from $image ...
+  Write-Output "Run first container from $image ..."
   docker run --rm $image cmd
 }
 

--- a/scripts/vm-guest-tools.ps1
+++ b/scripts/vm-guest-tools.ps1
@@ -15,33 +15,26 @@ if ("$env:PACKER_BUILDER_TYPE" -eq "vmware-iso") {
 
   if (!(Test-Path "C:\Windows\Temp\windows.iso")) {
     Try {
-      # Disabling the progress bar speeds up IWR https://github.com/PowerShell/PowerShell/issues/2138
       $ProgressPreference = 'SilentlyContinue'
-      $pageContentLinks = (Invoke-WebRequest('https://softwareupdate.vmware.com/cds/vmw-desktop/ws') -UseBasicParsing).Links | where-object { $_.href -Match "[0-9]" } | Select-Object href | ForEach-Object { $_.href.Trim('/') }
-      $versionObject = $pageContentLinks | ForEach-Object { new-object System.Version ($_) } | sort-object -Descending | select-object -First 1 -Property:Major, Minor, Build
-      $newestVersion = $versionObject.Major.ToString() + "." + $versionObject.Minor.ToString() + "." + $versionObject.Build.ToString() | out-string
-      $newestVersion = $newestVersion.TrimEnd("`r?`n")
-
-      $nextURISubdirectoryObject = (Invoke-WebRequest("https://softwareupdate.vmware.com/cds/vmw-desktop/ws/$newestVersion/") -UseBasicParsing).Links | where-object { $_.href -Match "[0-9]" } | Select-Object href | where-object { $_.href -Match "[0-9]" }
-      $nextUriSubdirectory = $nextURISubdirectoryObject.href | Out-String
-      $nextUriSubdirectory = $nextUriSubdirectory.TrimEnd("`r?`n")
-      $newestVMwareToolsURL = "https://softwareupdate.vmware.com/cds/vmw-desktop/ws/$newestVersion/$nextURISubdirectory/windows/packages/tools-windows.tar"
-      Write-Output "The latest version of VMware tools has been determined to be downloadable from $newestVMwareToolsURL"
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile("$newestVMwareToolsURL", 'C:\Windows\Temp\vmware-tools.tar')
+      $newestVMwareToolsURL = `
+        Invoke-WebRequest -Uri 'https://packages.vmware.com/tools/releases/latest/windows/' -UseBasicParsing | `
+        Select-Object -ExpandProperty Links | `
+        Where-Object { $_.href -like '*.iso' -and $_.href -notlike '*-arm-*' } | `
+        Select-Object -ExpandProperty href
+        Write-Output "The latest version of VMware tools has been determined to be downloadable from $newestVMwareToolsURL"
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+      (New-Object System.Net.WebClient).DownloadFile("$newestVMwareToolsURL", 'C:\Windows\Temp\windows.iso')
     }
     Catch {
       Write-Output "Unable to determine the latest version of VMware tools. Falling back to hardcoded URL."
-      (New-Object System.Net.WebClient).DownloadFile('https://softwareupdate.vmware.com/cds/vmw-desktop/ws/15.5.5/16285975/windows/packages/tools-windows.tar', 'C:\Windows\Temp\vmware-tools.tar')
+      (New-Object System.Net.WebClient).DownloadFile('https://packages.vmware.com/tools/releases/12.5.1/windows/VMware-tools-windows-12.5.1-24649672.iso', 'C:\Windows\Temp\windows.iso')
     }
-    cmd /c "C:\PROGRA~1\7-Zip\7z.exe" x C:\Windows\Temp\vmware-tools.tar -oC:\Windows\Temp
-    Move-Item c:\windows\temp\VMware-tools-windows-*.iso c:\windows\temp\windows.iso
     Try { Remove-Item "C:\Program Files (x86)\VMWare" -Recurse -Force -ErrorAction Stop } Catch { Write-Output "Directory didn't exist to be removed." }
   }
 
   cmd /c "C:\PROGRA~1\7-Zip\7z.exe" x "C:\Windows\Temp\windows.iso" -oC:\Windows\Temp\VMWare
   cmd /c C:\Windows\Temp\VMWare\setup.exe /S /v"/qn REBOOT=R\"
 
-  Remove-Item -Force "C:\Windows\Temp\vmware-tools.tar"
   Remove-Item -Force "C:\Windows\Temp\windows.iso"
   Remove-Item -Force -Recurse "C:\Windows\Temp\VMware"
 }

--- a/windows_2025_docker.json
+++ b/windows_2025_docker.json
@@ -80,7 +80,10 @@
         "./scripts/docker/enable-winrm.ps1",
         "./scripts/docker/2016/install-containers-feature.ps1",
         "./scripts/microsoft-updates.bat",
-        "./scripts/win-updates.ps1"
+        "./scripts/win-updates.ps1",
+        "./submodules/Debloat-Windows-10/scripts/disable-windows-defender.ps1",
+        "./submodules/Debloat-Windows-10/scripts/optimize-windows-update.ps1",
+        "./submodules/Debloat-Windows-10/lib/force-mkdir.psm1"
       ],
       "guest_os_type": "windows9srv-64",
       "headless": "{{user `headless`}}",


### PR DESCRIPTION
Current download links for VMware Tools are no longer valid.

Updating the links to the latest available VMWare Tools for Windows ISO.

