### PR TITLE
fixes sdelete download

### DIFF
--- a/scripts/compact.bat
+++ b/scripts/compact.bat
@@ -16,8 +16,7 @@ if not exist "C:\Windows\Temp\ultradefrag-portable-6.1.0.amd64\udefrag.exe" (
 )
 
 if not exist "C:\Windows\Temp\SDelete.zip" (
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://download.sysinternals.com/files/SDelete.zip', 'C:\Windows\Temp\SDelete.zip')" <NUL
-  powershell -Command "(New-Object System.Net.WebClient).DownloadFile('https://vagrantboxes.blob.core.windows.net/box/sdelete/v1.6.1/sdelete.exe', 'C:\Windows\Temp\sdelete.exe')" <NUL
+  powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://download.sysinternals.com/files/SDelete.zip', 'C:\Windows\Temp\SDelete.zip')" <NUL
 )
 
 if not exist "C:\Windows\Temp\sdelete.exe" (


### PR DESCRIPTION
https://vagrantboxes.blob.core.windows.net/box/sdelete/v1.6.1/sdelete.exe no longer exists
https://download.sysinternals.com/files/SDelete.zip download requires TLS1.2
fixes #341